### PR TITLE
Modern UI redesign — sidebar shell, density-aware switcher, sectioned…

### DIFF
--- a/TcNo-Acc-Switcher-Server/Data/PlatformAccountCounts.cs
+++ b/TcNo-Acc-Switcher-Server/Data/PlatformAccountCounts.cs
@@ -1,0 +1,79 @@
+// TcNo Account Switcher - A Super fast account switcher
+// Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
+//
+// Modern UI helper: counts saved accounts per platform from LoginCache on disk,
+// with a short cache so the home-screen render isn't an I/O hot loop.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TcNo_Acc_Switcher_Globals;
+
+namespace TcNo_Acc_Switcher_Server.Data
+{
+    public static class PlatformAccountCounts
+    {
+        private const int CacheSeconds = 5;
+        private static readonly object Lock = new();
+        private static Dictionary<string, int> _cache = new(StringComparer.OrdinalIgnoreCase);
+        private static DateTime _cacheStamp = DateTime.MinValue;
+
+        // Folders under LoginCache/<safe>/ that aren't accounts.
+        private static readonly HashSet<string> ReservedDirs = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Shortcuts"
+        };
+
+        public static int Count(string platformShort)
+        {
+            if (string.IsNullOrEmpty(platformShort)) return 0;
+            EnsureFresh();
+            var safe = BasicPlatforms.PlatformSafeName(platformShort);
+            return _cache.TryGetValue(safe, out var n) ? n : 0;
+        }
+
+        private static void EnsureFresh()
+        {
+            lock (Lock)
+            {
+                if ((DateTime.UtcNow - _cacheStamp).TotalSeconds < CacheSeconds && _cache.Count > 0) return;
+                _cache = BuildCounts();
+                _cacheStamp = DateTime.UtcNow;
+            }
+        }
+
+        private static Dictionary<string, int> BuildCounts()
+        {
+            var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var loginCache = Path.Join(Globals.UserDataFolder, "LoginCache");
+            if (!Directory.Exists(loginCache)) return result;
+
+            try
+            {
+                foreach (var platDir in Directory.EnumerateDirectories(loginCache))
+                {
+                    var safe = Path.GetFileName(platDir);
+                    if (string.IsNullOrEmpty(safe)) continue;
+                    int count = 0;
+                    try
+                    {
+                        count = Directory.EnumerateDirectories(platDir)
+                            .Count(d => !ReservedDirs.Contains(Path.GetFileName(d) ?? ""));
+                    }
+                    catch
+                    {
+                        count = 0;
+                    }
+                    result[safe] = count;
+                }
+            }
+            catch
+            {
+                // Disk error — return whatever we got. Empty result is fine.
+            }
+
+            return result;
+        }
+    }
+}

--- a/TcNo-Acc-Switcher-Server/Pages/Basic/Index.razor
+++ b/TcNo-Acc-Switcher-Server/Pages/Basic/Index.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -33,7 +33,68 @@
 <ContextMenu MenuItems="@Basic.ContextMenuShortcutItems" ContextMenuId="Shortcuts"/>
 <ContextMenu MenuItems="@Basic.ContextMenuPlatformItems" ContextMenuId="Platform"/>
 
-<AccountList AccountItems="@Basic.Accounts" AccountNotes="Basic.AccountNotes" @ref="BasicAccountList" />
+@{
+    var safe = CurrentPlatform.SafeName ?? "";
+    var safeClass = "p-" + safe.Replace(' ', '-');
+    var hasSvg = !string.IsNullOrEmpty(safe) &&
+                 File.Exists(Path.Join(TcNo_Acc_Switcher_Globals.Globals.UserDataFolder, $"wwwroot/img/platform/{safe}.svg"));
+    var letter = !string.IsNullOrEmpty(CurrentPlatform.FullName)
+                 ? CurrentPlatform.FullName[0].ToString().ToUpperInvariant() : "?";
+}
+
+<div class="m-platform-header">
+    <div class="m-platform-header-left">
+        <button type="button" class="m-btn m-btn-icon m-btn-ghost"
+                title="Back to all platforms" @onclick='@(() => NavManager.NavigateTo("/"))'>
+            <svg class="m-glyph" viewBox="0 0 16 16" style="width:14px; height:14px;"><path d="M10 3L5 8l5 5"></path></svg>
+        </button>
+        <div class="m-tile @safeClass" style="width:42px; height:42px; cursor:default;">
+            @if (hasSvg)
+            {
+                <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet">
+                    <use href="@($"img/platform/{safe}.svg#FG")" class="ico-fg"></use>
+                </svg>
+            }
+            else
+            {
+                <span class="m-tile-text">@letter</span>
+            }
+        </div>
+        <div class="m-platform-header-meta">
+            <div class="m-platform-header-title">@CurrentPlatform.FullName</div>
+            <div class="m-platform-header-sub">@Basic.Accounts.Count account@(Basic.Accounts.Count == 1 ? "" : "s")</div>
+        </div>
+    </div>
+
+    <div class="m-platform-header-right">
+        <input type="text" class="m-search" placeholder="Search accounts…"
+               value="@_filter" @oninput="@(e => _filter = e.Value?.ToString() ?? string.Empty)" />
+        <div class="m-density-toggle" title="Density">
+            <button type="button" class="m-density-btn @(Density == "tiles" ? "active" : "")" @onclick='@(() => SetDensity("tiles"))' title="Tiles">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2" width="5" height="5"></rect><rect x="9" y="2" width="5" height="5"></rect><rect x="2" y="9" width="5" height="5"></rect><rect x="9" y="9" width="5" height="5"></rect></svg>
+            </button>
+            <button type="button" class="m-density-btn @(Density == "rows" ? "active" : "")" @onclick='@(() => SetDensity("rows"))' title="Rows">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3" rx=".5"></rect><rect x="2" y="10" width="12" height="3" rx=".5"></rect></svg>
+            </button>
+            <button type="button" class="m-density-btn @(Density == "compact" ? "active" : "")" @onclick='@(() => SetDensity("compact"))' title="Compact">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 4h10M3 8h10M3 12h10"></path></svg>
+            </button>
+        </div>
+        <button type="button" class="m-btn m-btn-sm" id="btnAddNew" onclick="newLogin()" title="@(Locale["Button_AddNew"])">
+            <svg class="m-glyph" viewBox="0 0 16 16" style="width:12px; height:12px;"><path d="M8 3v10M3 8h10"></path></svg>
+            @Locale["Button_AddNew"]
+        </button>
+        <button type="button" class="m-btn m-btn-sm" id="btnAddCurrent" onclick="showModal('accString');" title="@(Locale["Button_SaveCurrent"])">
+            @Locale["Button_SaveCurrent"]
+        </button>
+        <button type="button" class="m-btn m-btn-sm m-btn-primary" id="btnLogin" onclick="tcnoSwitchSelected(event)">
+            @Locale["Button_Login"]
+        </button>
+    </div>
+</div>
+
+<AccountList AccountItems="@Basic.Accounts" AccountNotes="Basic.AccountNotes"
+             Density="@Density" Filter="@_filter" @ref="BasicAccountList" />
 
 <div class="shortcutDropdown gameShortcuts" id="shortcutDropdown" style="display: none">
     <div class="shortcutDropdownItems">
@@ -78,35 +139,22 @@
                 <img src="@(CurrentPlatform.GetShortcutImagePath(CurrentPlatform.SafeName))" alt="Start platform"/>
             </button>
         }
-
-        <button id="btnAddNew" onclick="newLogin()">
-            <i class="fas fa-plus footerIcoInline"></i>
-            <span>@Locale["Button_AddNew"]</span>
-        </button>
-        <button id="btnAddCurrent" onclick="showModal('accString');">
-            <i class="fas fa-save footerIcoInline"></i>
-            <span>@Locale["Button_SaveCurrent"]</span>
-        </button>
-        <button class="btn_login" id="btnLogin" onclick="swapTo(-1, event)">
-            <span>@Locale["Button_Login"]</span>
-            <i class="fas fa-caret-right footerIcoInline"></i>
-        </button>
-
-        <button id="btnSettings" onclick="location = 'Basic/Settings'" data-toggle="tooltip" title="@(Locale["Tooltip_Settings"])">
-            <i class="fas fa-cog footerIcoSettings"></i>
-        </button>
-
-        <button id="btnHelp" onclick="showModal('info');" data-toggle="tooltip" title="@(Locale["Tooltip_Info"])">
-            <i class="fas fa-question footerIcoQuestion"></i>
-        </button>
     </div>
-
 </div>
 
 
 @code
 {
     public static AccountList BasicAccountList;
+
+    private string _filter = "";
+    private string Density { get; set; } = "tiles";
+
+    private async Task SetDensity(string d)
+    {
+        Density = d;
+        try { await JsRuntime.InvokeVoidAsync("tcnoSetDensity", d); } catch { /* noop */ }
+    }
 
     private string RemoveShortcutExt(string s)
     {
@@ -157,6 +205,14 @@
         await GeneralFuncs.HandleFirstRender(firstRender, CurrentPlatform.FullName);
         AppStats.NewNavigation($"/[{CurrentPlatform.SafeName}]");
         if (!firstRender) return;
+
+        try
+        {
+            var saved = await JsRuntime.InvokeAsync<string>("tcnoGetDensity");
+            if (!string.IsNullOrEmpty(saved) && saved != Density) { Density = saved; StateHasChanged(); }
+        }
+        catch { /* noop */ }
+
         _ = AppData.InvokeVoidAsync("initCopyHotKey");
         _ = AppData.InvokeVoidAsync("showNoteTooltips");
 

--- a/TcNo-Acc-Switcher-Server/Pages/Index.razor
+++ b/TcNo-Acc-Switcher-Server/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
 @using System.Globalization
 @using System.IO
 @using TcNo_Acc_Switcher_Globals
-@using System.Configuration
 @inject IJSRuntime JsRuntime
 @{ AData.SetActiveIJsRuntime(JsRuntime); }
 @inject NavigationManager NavManager
@@ -37,85 +36,124 @@
 }
 
 <ContextMenu MenuItems="@AppSettings.PlatformContextMenuItems" ContextMenuId="AccOrPlatList" />
-<div class="platformTable">
-    <div class="platform_list">
-        @foreach (var platform in AData.SortedPlatformListHandleDisabled())
-        {
-            <div class="platform_list_item" id="@(platform)" @onclick="() => Check(platform)">
-                <div class="fgText @(!File.Exists(Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{BasicPlatforms.PlatformSafeName(platform)}.svg")) ? "noImageCenterText" : "") @(BasicPlatforms.PlatformFullName(platform).Length < 7 ? "shortText" : BasicPlatforms.PlatformFullName(platform).Length > 12 ? "longText" : "")"><p>@BasicPlatforms.PlatformFullName(platform).ToUpper(CultureInfo.InvariantCulture)</p></div>
-                <div class="fgImg">
-                    @if(File.Exists(Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{BasicPlatforms.PlatformSafeName(platform)}.svg")))
-                    {
-                        <svg viewBox="0 0 500 500" draggable="false" alt="@(BasicPlatforms.PlatformSafeName(platform))">
-                            <use href="@($"img/platform/{BasicPlatforms.PlatformSafeName(platform)}.svg#FG")" class="@("icoFG")"></use>
-                        </svg>
-                    }
-                </div>
-                <svg viewBox="0 0 2084 2084" draggable="false" alt="@(platform)" class="@("icoBG")">
-                    <use href="img/platform/glass.svg#GLASS" class="icoGlass @("icoGlass")"></use>
-                </svg>
-            </div>
-        }
+
+@{
+    var platforms = AData.SortedPlatformListHandleDisabled();
+    var totalAccounts = platforms.Sum(p => PlatformAccountCounts.Count(p));
+}
+
+<div class="m-content-header">
+    <div>
+        <div class="m-content-title">Accounts</div>
+        <div class="m-content-sub">
+            @platforms.Count platform@(platforms.Count == 1 ? "" : "s")
+            @if (totalAccounts > 0)
+            {
+                <span> · @totalAccounts account@(totalAccounts == 1 ? "" : "s") managed</span>
+            }
+        </div>
+    </div>
+    <div style="display:flex; gap:8px;">
+        <button class="m-btn m-btn-sm" @onclick="@(() => NavManager.NavigateTo("/Platforms"))" data-toggle="tooltip" title="@(Locale["Tooltip_ManagePlatforms"])">
+            <svg class="m-glyph" viewBox="0 0 16 16" style="width:12px; height:12px;"><path d="M8 3v10M3 8h10"></path></svg>
+            @Locale["Button_ManagePlatforms"]
+        </button>
     </div>
 </div>
 
-<div class="acc_list_actionbar">
-    <div>
-        @*<button id="btnTextEditor" onclick="location = 'TextEditor'">
-            <i class="fas fa-cog footerIcoSettings"></i>
-        </button>*@
-        @if (BasicPlatforms.PlatformDict.Count > 0)
-        {
-            <button id="btnPlatforms" onclick="location = 'Platforms'" data-toggle="tooltip" title="@(Locale["Tooltip_ManagePlatforms"])">
-                <i class="fas fa-plus footerIcoInline"></i>
-                @Lang["Button_ManagePlatforms"]
-            </button>
-        }
-        <button id="btnSettings" onclick="location = 'Settings'" data-toggle="tooltip" title="@(Locale["Tooltip_Settings"])">
-            <i class="fas fa-cog footerIcoSettings"></i>
-        </button>
-        <button id="btnHelp" onclick="showModal('info');" data-toggle="tooltip" title="@(Locale["Tooltip_Info"])">
-            <i class="fas fa-question footerIcoQuestion"></i>
-        </button>
+<div class="m-content-body">
+    <div class="m-home-cols">
+        <div>
+            <div class="m-section-label">
+                <div class="m-eyebrow">All platforms</div>
+            </div>
+            <div class="m-platform-grid">
+                @foreach (var platform in platforms)
+                {
+                    var safe = BasicPlatforms.PlatformSafeName(platform);
+                    var fullName = BasicPlatforms.PlatformFullName(platform);
+                    var safeClass = "p-" + safe.Replace(' ', '-');
+                    var svgPath = Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{safe}.svg");
+                    var hasSvg = File.Exists(svgPath);
+                    var letter = !string.IsNullOrEmpty(fullName) ? fullName[0].ToString().ToUpperInvariant() : "?";
+
+                    var count = PlatformAccountCounts.Count(platform);
+                    <div class="m-platform-card HasContextMenu" id="@platform" @onclick="() => Check(platform)">
+                        <div class="m-tile @safeClass" style="width:48px; height:48px; cursor:default;">
+                            @if (hasSvg)
+                            {
+                                <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet" draggable="false">
+                                    <use href="@($"img/platform/{safe}.svg#FG")" class="ico-fg"></use>
+                                </svg>
+                            }
+                            else
+                            {
+                                <span class="m-tile-text">@letter</span>
+                            }
+                        </div>
+                        <div>
+                            <div class="m-platform-card-name">@fullName</div>
+                            <div class="m-platform-card-count">
+                                @(count == 0 ? "No accounts yet" : $"{count} account{(count == 1 ? "" : "s")}")
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div>
+            <div class="m-section-label">
+                <div class="m-eyebrow">Recent activity</div>
+            </div>
+            <div class="m-activity-rail">
+                <div class="m-activity-empty">No recent switches yet.</div>
+            </div>
+        </div>
     </div>
 </div>
 
 @code
 {
-	// This is run before everything is painted on, so that it can get the correct values for the CSS Block.
-	protected override void OnParametersSet()
-	{
-	}
+    // This is run before everything is painted on, so that it can get the correct values for the CSS Block.
+    protected override void OnParametersSet()
+    {
+    }
 
-	protected override void OnAfterRender(bool firstRender)
-	{
-		AppData.Instance.WindowTitle = "TcNo Account Switcher";
+    protected override void OnAfterRender(bool firstRender)
+    {
+        AppData.Instance.WindowTitle = "TcNo Account Switcher";
+
+        // First-launch: send the user through onboarding once.
+        if (firstRender && !Welcome.IsOnboarded())
+        {
+            NavManager.NavigateTo("/Welcome");
+            return;
+        }
 
         // If no platforms are showing:
-	    if (!AData.AnyPlatformsShowing())
-	    {
+        if (!AData.AnyPlatformsShowing())
+        {
             NavManager.NavigateTo("Platforms");
-	    }
+        }
 
         // If just 1 platform is showing, and first launch: Nav into:
-	    if (AppData.FirstMainMenuVisit && AData.SortedPlatformListHandleDisabled().Count == 1)
-	    {
-	        AppData.FirstMainMenuVisit = false;
-	        var onlyPlatform = AData.SortedPlatformListHandleDisabled().First();
-	        Check(onlyPlatform);
-	    }
-	    AppData.FirstMainMenuVisit = false;
+        if (AppData.FirstMainMenuVisit && AData.SortedPlatformListHandleDisabled().Count == 1)
+        {
+            AppData.FirstMainMenuVisit = false;
+            var onlyPlatform = AData.SortedPlatformListHandleDisabled().First();
+            Check(onlyPlatform);
+        }
+        AppData.FirstMainMenuVisit = false;
 
-	    if (firstRender)
-		{
-			GeneralFuncs.HandleQueries();
-		    _ = AppData.InvokeVoidAsync("initContextMenu");
-		    _ = AppData.InvokeVoidAsync("initPlatformListSortable");
-			//await AData.InvokeVoidAsync("initAccListSortable");
-		}
+        if (firstRender)
+        {
+            GeneralFuncs.HandleQueries();
+            _ = AppData.InvokeVoidAsync("initContextMenu");
+        }
 
-	    AppData.FirstLaunchCheck();
+        AppData.FirstLaunchCheck();
 
-	    AppStats.NewNavigation("/");
-	}
+        AppStats.NewNavigation("/");
+    }
 }

--- a/TcNo-Acc-Switcher-Server/Pages/Settings.razor
+++ b/TcNo-Acc-Switcher-Server/Pages/Settings.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,33 +22,58 @@
 @{ AData.SetActiveIJsRuntime(JsRuntime); }
 @inject Lang Locale
 
-<div class="container mainblock">
-    <div class="row">
-        <div class="col-md-12 col-lg-9 col-xl-8 mx-auto settingsCol">
-            <div class="toastarea"></div>
-            <SharedSettings />
-
-            <div class="buttoncol col_close"><button class="btn_close" type="button" @onclick="SaveAndClose"><span>@Locale["Button_Close"]</span></button></div>
-        </div>
+<div class="m-content-header">
+    <div>
+        <div class="m-content-title">@Locale["Settings_Header_AppWide"]</div>
+        <div class="m-content-sub">App-wide preferences</div>
+    </div>
+    <div>
+        <button class="m-btn m-btn-sm m-btn-primary" @onclick="SaveAndClose">@Locale["Button_Close"]</button>
     </div>
 </div>
-<div id="blazor-error-ui">
-    <environment include="Staging,Production">
-        An error has occurred. This application may no longer respond until reloaded.
-    </environment>
-    <environment include="Development">
-        An unhandled exception has occurred. See browser dev tools for details.
-    </environment>
-    <a href="">Reload</a>
-    <a class="dismiss">🗙</a>
+
+<div class="m-set-shell">
+    <div class="m-set-nav">
+        @foreach (var (id, label) in Sections)
+        {
+            <div class="m-set-nav-item @(_active == id ? "active" : "")" @onclick="() => Navigate(id)">
+                @label
+            </div>
+        }
+    </div>
+    <div class="m-set-pane" id="set-pane">
+        <div class="toastarea"></div>
+        <SharedSettings />
+    </div>
 </div>
 
 @code
 {
+    private string _active = "language";
+
+    private static readonly (string id, string label)[] Sections = new[]
+    {
+        ("language", "Language"),
+        ("theme", "Theme"),
+        ("system", "System"),
+        ("program", "Program"),
+        ("statssharing", "Stats & Sharing"),
+    };
+
+    private async Task Navigate(string id)
+    {
+        _active = id;
+        // Scroll the matching <h2 class="SettingsHeader"> into view inside the pane.
+        try
+        {
+            await JsRuntime.InvokeVoidAsync("tcnoScrollSettingsTo", id);
+        }
+        catch { /* noop */ }
+    }
+
     public void SaveAndClose()
     {
         AppSettings.SaveSettings();
-
         NavManager.NavigateTo("/");
     }
 

--- a/TcNo-Acc-Switcher-Server/Pages/Steam/Index.razor
+++ b/TcNo-Acc-Switcher-Server/Pages/Steam/Index.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -31,7 +31,50 @@
 <ContextMenu MenuItems="@Steam.Menu" ContextMenuId="AccOrPlatList" @ref="SteamContextMenu" />
 <ContextMenu MenuItems="@Basic.ContextMenuShortcutItems" ContextMenuId="Shortcuts" />
 <ContextMenu MenuItems="@Basic.ContextMenuPlatformItems" ContextMenuId="Platform" />
-<AccountList AccountItems="@Steam.Accounts" AccountNotes="Steam.AccountNotes" @ref="SteamAccountList" />
+
+<div class="m-platform-header">
+    <div class="m-platform-header-left">
+        <button type="button" class="m-btn m-btn-icon m-btn-ghost"
+                title="Back to all platforms" @onclick='@(() => NavManager.NavigateTo("/"))'>
+            <svg class="m-glyph" viewBox="0 0 16 16" style="width:14px; height:14px;"><path d="M10 3L5 8l5 5"></path></svg>
+        </button>
+        <div class="m-tile p-Steam" style="width:42px; height:42px; cursor:default;">
+            <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet">
+                <use href="img/platform/steam.svg#FG" class="ico-fg"></use>
+            </svg>
+        </div>
+        <div class="m-platform-header-meta">
+            <div class="m-platform-header-title">Steam</div>
+            <div class="m-platform-header-sub">@Steam.Accounts.Count account@(Steam.Accounts.Count == 1 ? "" : "s")</div>
+        </div>
+    </div>
+
+    <div class="m-platform-header-right">
+        <input type="text" class="m-search" placeholder="Search accounts…"
+               value="@_filter" @oninput="@(e => _filter = e.Value?.ToString() ?? string.Empty)" />
+        <div class="m-density-toggle" title="Density">
+            <button type="button" class="m-density-btn @(Density == "tiles" ? "active" : "")" @onclick='@(() => SetDensity("tiles"))' title="Tiles">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2" width="5" height="5"></rect><rect x="9" y="2" width="5" height="5"></rect><rect x="2" y="9" width="5" height="5"></rect><rect x="9" y="9" width="5" height="5"></rect></svg>
+            </button>
+            <button type="button" class="m-density-btn @(Density == "rows" ? "active" : "")" @onclick='@(() => SetDensity("rows"))' title="Rows">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3" rx=".5"></rect><rect x="2" y="10" width="12" height="3" rx=".5"></rect></svg>
+            </button>
+            <button type="button" class="m-density-btn @(Density == "compact" ? "active" : "")" @onclick='@(() => SetDensity("compact"))' title="Compact">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M3 4h10M3 8h10M3 12h10"></path></svg>
+            </button>
+        </div>
+        <button type="button" class="m-btn m-btn-sm" id="btnAddNew" onclick="newLogin()" title="@(Locale["Button_AddNew"])">
+            <svg class="m-glyph" viewBox="0 0 16 16" style="width:12px; height:12px;"><path d="M8 3v10M3 8h10"></path></svg>
+            @Locale["Button_AddNew"]
+        </button>
+        <button type="button" class="m-btn m-btn-sm m-btn-primary" id="btnLogin" onclick="tcnoSwitchSelected(event)">
+            @Locale["Button_Login"]
+        </button>
+    </div>
+</div>
+
+<AccountList AccountItems="@Steam.Accounts" AccountNotes="Steam.AccountNotes"
+             Density="@Density" Filter="@_filter" @ref="SteamAccountList" />
 
 <div class="shortcutDropdown gameShortcuts" id="shortcutDropdown" style="display: none">
     <div class="shortcutDropdownItems">
@@ -67,24 +110,7 @@
         <button id="btnStartPlat" @onclick='() => Basic.RunPlatform(Steam.Exe(), Steam.Admin, "", "Steam", Steam.StartingMethod)' data-toggle="tooltip" title="Steam">
             <img src="@(Steam.GetShortcutImagePath("Steam"))" alt="Start platform"/>
         </button>
-
-        <button id="btnAddNew" onclick="newLogin()">
-            <i class="fas fa-plus footerIcoInline"></i>
-            <span>@Locale["Button_AddNew"]</span>
-        </button>
-        <button class="btn_login" id="btnLogin" onclick="swapTo(-1, event)">
-            <span>@Locale["Button_Login"]</span>
-            <i class="fas fa-caret-right footerIcoInline"></i>
-        </button>
-
-        <button id="btnSettings" onclick="location = 'Steam/Settings'" data-toggle="tooltip" title="@(Locale["Tooltip_Settings"])">
-            <i class="fas fa-cog footerIcoSettings"></i>
-        </button>
-        <button id="btnHelp" onclick="showModal('info');" data-toggle="tooltip" title="@(Locale["Tooltip_Info"])">
-            <i class="fas fa-question footerIcoQuestion"></i>
-        </button>
     </div>
-
 </div>
 
 
@@ -93,21 +119,37 @@
     public static AccountList SteamAccountList;
 
     public static ContextMenu SteamContextMenu;
+
+    private string _filter = "";
+    private string Density { get; set; } = "tiles";
+
+    private async Task SetDensity(string d)
+    {
+        Density = d;
+        try { await JsRuntime.InvokeVoidAsync("tcnoSetDensity", d); } catch { /* noop */ }
+    }
+
     // This has to be here for NavManager.
     // This is run before everything is painted on, so that it can get the correct values for the CSS Block.
     protected override void OnParametersSet()
     {
         AppSettings.StreamerModeCheck();
         BasicStats.SetCurrentPlatform("Steam");
-        //var f = AppSettings.UsingTcNoBrowser;
     }
 
-    //protected override async Task OnAfterRenderAsync(bool firstRender) => await GeneralFuncs.HandleFirstRender(firstRender, "Steam");
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await GeneralFuncs.HandleFirstRender(firstRender, "Steam");
         AppStats.NewNavigation("/Steam/");
         if (!firstRender) return;
+
+        try
+        {
+            var saved = await JsRuntime.InvokeAsync<string>("tcnoGetDensity");
+            if (!string.IsNullOrEmpty(saved) && saved != Density) { Density = saved; StateHasChanged(); }
+        }
+        catch { /* noop */ }
+
         _ = AppData.InvokeVoidAsync("initCopyHotKey");
         _ = AppData.InvokeVoidAsync("showNoteTooltips");
 

--- a/TcNo-Acc-Switcher-Server/Pages/Welcome.razor
+++ b/TcNo-Acc-Switcher-Server/Pages/Welcome.razor
@@ -1,0 +1,197 @@
+@*TcNo Account Switcher - A Super fast account switcher
+    Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
+    Modern UI first-launch onboarding flow.*@
+
+@page "/Welcome"
+@using System.IO
+@using TcNo_Acc_Switcher_Globals
+@using TcNo_Acc_Switcher_Server.Data
+@inject NavigationManager NavManager
+@inject AppData AData
+@inject IJSRuntime JsRuntime
+@{ AData.SetActiveNavMan(NavManager); }
+
+@code {
+    private int _step = 0;
+    private const int TotalSteps = 3;
+
+    private static string OnboardedMarker => Path.Join(Globals.UserDataFolder, ".onboarded");
+
+    public static bool IsOnboarded() => File.Exists(OnboardedMarker);
+
+    private async Task Next()
+    {
+        if (_step < TotalSteps - 1) { _step++; StateHasChanged(); return; }
+        await Finish();
+    }
+
+    private void Back()
+    {
+        if (_step > 0) { _step--; StateHasChanged(); }
+    }
+
+    private async Task Finish()
+    {
+        try
+        {
+            Directory.CreateDirectory(Globals.UserDataFolder);
+            await File.WriteAllTextAsync(OnboardedMarker, DateTime.UtcNow.ToString("O"));
+        }
+        catch
+        {
+            // Don't block the user if the marker can't be written; they'll just see onboarding again next launch.
+        }
+        NavManager.NavigateTo("/");
+    }
+
+    private List<string> Detected()
+    {
+        var list = new List<string>();
+        try
+        {
+            // Steam: present if the platform list has it (it always does until disabled).
+            if (AData.PlatformList.Contains("Steam") && !AppSettings.DisabledPlatforms.Contains("Steam"))
+                list.Add("Steam");
+            var basics = AppSettings.EnabledBasicPlatforms ?? (System.Collections.Generic.IEnumerable<string>)System.Array.Empty<string>();
+            foreach (var p in basics)
+            {
+                if (!AppSettings.DisabledPlatforms.Contains(p)) list.Add(p);
+            }
+        }
+        catch { }
+        return list;
+    }
+
+}
+
+<div class="m-onb-shell">
+    <div class="m-onb-topbar">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+            <rect x="2" y="2" width="20" height="20" rx="5" fill="var(--m-accent)" />
+            <path d="M7 9h10M12 9v8" stroke="#fff" stroke-width="2.4" stroke-linecap="round" />
+        </svg>
+        <span class="m-onb-topbar-name" style="margin-left:8px;">Set up TcNo</span>
+        <div class="m-onb-step-dots">
+            @for (var i = 0; i < TotalSteps; i++)
+            {
+                var cls = i < _step ? "done" : (i == _step ? "active" : "");
+                <div class="m-onb-dot @cls"></div>
+            }
+        </div>
+    </div>
+
+    <div class="m-onb-body">
+        @if (_step == 0)
+        {
+            <div class="m-onb-welcome">
+                <div class="m-onb-welcome-mark">
+                    <svg width="44" height="44" viewBox="0 0 24 24" fill="none">
+                        <rect x="2" y="2" width="20" height="20" rx="5" fill="var(--m-accent)" />
+                        <path d="M7 9h10M12 9v8" stroke="#fff" stroke-width="2.4" stroke-linecap="round" />
+                    </svg>
+                </div>
+                <div class="m-onb-welcome-title">One switcher for every account.</div>
+                <div class="m-onb-welcome-sub">
+                    TcNo manages multiple accounts on Steam, Epic, Battle.net, Riot, Ubisoft, Discord, and 30+ more — without juggling passwords.
+                </div>
+                <div class="m-onb-welcome-tiles">
+                    @foreach (var p in new[] { "Steam", "Epic Games", "BattleNet", "Riot Games", "Discord", "Ubisoft", "EA Desktop", "Rockstar" })
+                    {
+                        var safeClass = "p-" + p.Replace(' ', '-');
+                        var hasSvg = File.Exists(Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{p}.svg"));
+                        <div class="m-tile @safeClass" style="width:48px; height:48px; cursor:default;">
+                            @if (hasSvg)
+                            {
+                                <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet">
+                                    <use href="@($"img/platform/{p}.svg#FG")" class="ico-fg"></use>
+                                </svg>
+                            }
+                            else
+                            {
+                                <span class="m-tile-text">@p[0]</span>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+        else if (_step == 1)
+        {
+            var detected = Detected();
+            <div class="m-onb-detect">
+                <div class="m-onb-detect-title">Confirm what we found.</div>
+                <div class="m-onb-detect-sub">
+                    @if (detected.Count == 0)
+                    {
+                        <span>We didn't auto-detect any installed launchers yet — that's fine. You can add platforms anytime from Manage&nbsp;platforms.</span>
+                    }
+                    else
+                    {
+                        <span>We scanned your machine for installed launchers. You can change this later in Manage&nbsp;platforms.</span>
+                    }
+                </div>
+                @if (detected.Count > 0)
+                {
+                    <div class="m-onb-detect-grid">
+                        @foreach (var p in detected)
+                        {
+                            var safe = BasicPlatforms.PlatformSafeName(p);
+                            var safeClass = "p-" + safe.Replace(' ', '-');
+                            var fullName = BasicPlatforms.PlatformFullName(p);
+                            var hasSvg = File.Exists(Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{safe}.svg"));
+                            <div class="m-onb-detect-item">
+                                <div class="m-tile @safeClass" style="width:36px; height:36px; cursor:default;">
+                                    @if (hasSvg)
+                                    {
+                                        <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet">
+                                            <use href="@($"img/platform/{safe}.svg#FG")" class="ico-fg"></use>
+                                        </svg>
+                                    }
+                                    else
+                                    {
+                                        <span class="m-tile-text" style="font-size:12px;">@(fullName.Length > 0 ? fullName[0].ToString() : "?")</span>
+                                    }
+                                </div>
+                                <div style="min-width:0; flex:1;">
+                                    <div class="m-onb-detect-item-name">@fullName</div>
+                                    <div class="m-onb-detect-item-status">Detected</div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+        }
+        else
+        {
+            <div class="m-onb-hotkey">
+                <div class="m-onb-hotkey-title">You're set.</div>
+                <div class="m-onb-hotkey-sub">
+                    TcNo lives in the system tray once you close the window. Use Settings → System to control startup, hotkeys, and the streamer-mode privacy toggle.
+                </div>
+                <div class="m-onb-hotkey-display">
+                    <span class="m-kbd">Ctrl</span>
+                    <span class="m-kbd">,</span>
+                </div>
+                <div style="margin-top: 16px; color: var(--m-text-3); font-size: 12px;">
+                    Open Settings anytime from the sidebar.
+                </div>
+            </div>
+        }
+    </div>
+
+    <div class="m-onb-footer">
+        <button type="button" class="m-btn m-btn-ghost" disabled="@(_step == 0)"
+                style="@(_step == 0 ? "opacity:.4;" : "")"
+                @onclick="Back">Back</button>
+        <div class="m-onb-spacer"></div>
+        @if (_step < TotalSteps - 1)
+        {
+            <button type="button" class="m-btn m-btn-primary" @onclick="Next">Continue</button>
+        }
+        else
+        {
+            <button type="button" class="m-btn m-btn-primary" @onclick="Finish">Open TcNo</button>
+        }
+    </div>
+</div>

--- a/TcNo-Acc-Switcher-Server/Pages/_Host.cshtml
+++ b/TcNo-Acc-Switcher-Server/Pages/_Host.cshtml
@@ -42,12 +42,16 @@
     <link href="css/settings.min.css?@currentTime" rel="stylesheet" />
     <link href="css/notification.min.css?@currentTime" rel="stylesheet" />
     <link href="css/fontawesome.all.min.css?@currentTime" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="css/modern.css?@currentTime" rel="stylesheet" />
     <script src="js/ace/ace.js?@currentTime" type="text/javascript" charset="utf-8"></script>
     <script>if (window.module) module = window.module;</script>
     <script src="js/interop.js?@currentTime"></script>
     <script src="js/hotkeys.min.js?@currentTime"></script>
 </head>
-<body>
+<body class="modern-active">
     <app>
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
@@ -67,6 +71,7 @@
     <script src="js/context_menu.js?@currentTime"></script>
     <script src="js/WebFuncs.js?@currentTime"></script>
     <script src="js/Headerbar.js?@currentTime"></script>
+    <script src="js/modern.js?@currentTime"></script>
     <script type="module">
         import Notification from './js/Notification.min.js';
         window.notification = new Notification({

--- a/TcNo-Acc-Switcher-Server/Shared/Accounts/AccountItem.razor
+++ b/TcNo-Acc-Switcher-Server/Shared/Accounts/AccountItem.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -17,41 +17,77 @@
 @using TcNo_Acc_Switcher_Globals
 @using TcNo_Acc_Switcher_Server.Data.Settings
 @using TcNo_Acc_Switcher_Server.Pages.General
+@inject IJSRuntime Js
+
 @code {
-    [Parameter]
-    public Account Acc { get; set; }
-    [CascadingParameter]
-    public Dictionary<string, string> AccountNotes { get; set; }
+    [Parameter] public Account Acc { get; set; }
+    [CascadingParameter] public Dictionary<string, string> AccountNotes { get; set; }
+    [CascadingParameter] public string Density { get; set; } = "tiles";
+
+    private bool _editing;
+    private string _draft = "";
+
+    private string CurrentNote =>
+        (AccountNotes != null && AccountNotes.TryGetValue(Acc.AccountId, out var n)) ? n ?? "" : "";
+
+    private void StartEdit()
+    {
+        _draft = CurrentNote;
+        _editing = true;
+    }
+
+    private async Task CommitEdit()
+    {
+        if (!_editing) return;
+        _editing = false;
+        if (AccountNotes != null) AccountNotes[Acc.AccountId] = _draft ?? "";
+        try
+        {
+            await Js.InvokeVoidAsync("tcnoSaveNote", Acc.AccountId, _draft ?? "");
+        }
+        catch
+        {
+            // JS call may fail during prerender or if the page-specific Set*Notes isn't available; the in-memory
+            // dictionary is still updated so the UI stays consistent.
+        }
+        StateHasChanged();
+    }
+
+    private void CancelEdit() { _editing = false; StateHasChanged(); }
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await CommitEdit();
+        else if (e.Key == "Escape") CancelEdit();
+    }
 }
 
-<div class="acc_list_item" data-toggle="tooltip" draggable="true" role="option" aria-grabbed="false">
+<div class="acc_list_item HasContextMenu" data-toggle="tooltip" draggable="true" role="option" aria-grabbed="false">
     <input type="radio" id="@Acc.AccountId" DisplayName="@GeneralFuncs.EscapeText(Acc.DisplayName)" class="acc" name="accounts" onchange="selectedItemChanged()">
     <label for="@Acc.AccountId" class="acc @Acc.Classes.Label">
         <img class="@Acc.Classes.Image" src="@Acc.ImagePath?@Globals.GetUnixTime()" draggable="false" alt="" onerror="if (this.src != 'img/BasicDefault.png') this.src = 'img/BasicDefault.png';" />
-        @if (@Acc.Line0 != "")
+
+        @if (!string.IsNullOrEmpty(Acc.Line0))
         {
             <p class="@Acc.Classes.Line0">@Acc.Line0</p>
         }
         <h6 class="displayName">@GeneralFuncs.EscapeText(Acc.DisplayName)</h6>
-        @if (@Acc.Line2 != "")
+        @if (!string.IsNullOrEmpty(Acc.Line2))
         {
             <p class="@Acc.Classes.Line2">@Acc.Line2</p>
         }
-        @if (@Acc.Line3 != "")
+        @if (!string.IsNullOrEmpty(Acc.Line3))
         {
             <p class="@Acc.Classes.Line3">@Acc.Line3</p>
         }
-        @if (AccountNotes.ContainsKey(Acc.AccountId) && AccountNotes[Acc.AccountId] != "")
-        {
-            <p class="acc_note">@AccountNotes[Acc.AccountId]</p>
-        }
-        @if (Acc.UserStats.Keys.Count > 0)
+
+        @if (Acc.UserStats != null && Acc.UserStats.Keys.Count > 0)
         {
             @foreach (var game in Acc.UserStats)
             {
                 var gameName = game.Key;
                 var gameStats = game.Value;
-                foreach (var gameStat in gameStats)
+                @foreach (var gameStat in gameStats)
                 {
                     @if (!AppSettings.GloballyHiddenMetrics[gameName][gameStat.Key])
                     {
@@ -60,5 +96,38 @@
                 }
             }
         }
+
+        <div class="m-acct-actions" @onclick:stopPropagation="true">
+            @if (_editing)
+            {
+                <input class="m-note-input"
+                       value="@_draft"
+                       autofocus
+                       @oninput="@(e => _draft = e.Value?.ToString() ?? string.Empty)"
+                       @onkeydown="OnKeyDown"
+                       @onblur="CommitEdit" />
+            }
+            else if (!string.IsNullOrEmpty(CurrentNote))
+            {
+                <span class="m-note" title="@CurrentNote — click to edit"
+                      @onclick="StartEdit" @onclick:stopPropagation="true">@CurrentNote</span>
+            }
+            else
+            {
+                <button type="button" class="m-note-add"
+                        @onclick="StartEdit" @onclick:stopPropagation="true">
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M11 2l3 3-8 8H3v-3z"></path></svg>
+                    Note
+                </button>
+            }
+            @if (Density == "rows" || Density == "compact")
+            {
+                <button type="button" class="m-btn m-btn-sm m-btn-primary"
+                        onclick="tcnoSwitchAccount('@Acc.AccountId', '@GeneralFuncs.EscapeText(Acc.DisplayName)', event)"
+                        @onclick:stopPropagation="true">
+                    Switch
+                </button>
+            }
+        </div>
     </label>
 </div>

--- a/TcNo-Acc-Switcher-Server/Shared/Accounts/AccountList.razor
+++ b/TcNo-Acc-Switcher-Server/Shared/Accounts/AccountList.razor
@@ -1,4 +1,4 @@
-﻿@*TcNo Account Switcher - A Super fast account switcher
+@*TcNo Account Switcher - A Super fast account switcher
     Copyright (C) 2019-2025 TroubleChute (Wesley Pyburn)
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,18 +22,62 @@
     public ObservableCollection<Account> AccountItems { get; set; }
     [Parameter]
     public Dictionary<string, string> AccountNotes { get; set; }
+    [Parameter]
+    public string Density { get; set; } = "tiles"; // tiles | rows | compact
+    [Parameter]
+    public string Filter { get; set; } = "";
 
     protected override void OnInitialized()
     {
         AccountItems.CollectionChanged += ((_, _) => InvokeAsync(StateHasChanged));
     }
-}
-<div id="acc_list" class="acc_list">
-    <toastarea class="toastarea"/>
-    @foreach (var item in AccountItems)
+
+    private string DensityClass => Density switch
     {
-        <CascadingValue Value="@AccountNotes">
-            <AccountItem Acc="@item" />
-        </CascadingValue>
+        "rows" => "m-density-rows",
+        "compact" => "m-density-compact",
+        _ => "m-density-tiles"
+    };
+
+    private bool Matches(Account a)
+    {
+        if (string.IsNullOrEmpty(Filter)) return true;
+        var f = Filter.Trim();
+        if (string.IsNullOrEmpty(f)) return true;
+        return (a.DisplayName?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (a.Line0?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (a.Line2?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (a.Line3?.Contains(f, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+}
+
+<div id="acc_list" class="acc_list @DensityClass">
+    <toastarea class="toastarea" />
+    @{
+        var visible = AccountItems.Where(Matches).ToList();
+    }
+    @if (visible.Count == 0)
+    {
+        <div class="m-empty-state">
+            @if (string.IsNullOrEmpty(Filter))
+            {
+                <span>No accounts yet. Use “+ Add account” to capture the one you’re currently signed in to.</span>
+            }
+            else
+            {
+                <span>No accounts match “@Filter”.</span>
+            }
+        </div>
+    }
+    else
+    {
+        @foreach (var item in visible)
+        {
+            <CascadingValue Value="@AccountNotes">
+                <CascadingValue Value="@Density">
+                    <AccountItem Acc="@item" />
+                </CascadingValue>
+            </CascadingValue>
+        }
     }
 </div>

--- a/TcNo-Acc-Switcher-Server/Shared/MainLayout.razor
+++ b/TcNo-Acc-Switcher-Server/Shared/MainLayout.razor
@@ -31,7 +31,12 @@
 <div class="resizeBottomLeft"></div>
 <div class="programMain">
     <Modal />
-    @Body
+    <div class="app-shell">
+        <Sidebar />
+        <div class="m-content">
+            @Body
+        </div>
+    </div>
 </div>
 <DynamicStylesheet />
 

--- a/TcNo-Acc-Switcher-Server/Shared/Sidebar.razor
+++ b/TcNo-Acc-Switcher-Server/Shared/Sidebar.razor
@@ -1,0 +1,168 @@
+@*TcNo Account Switcher — Modern UI sidebar.*@
+@using System.IO
+@using TcNo_Acc_Switcher_Globals
+@using TcNo_Acc_Switcher_Server.Data
+@using TcNo_Acc_Switcher_Server.Pages.General
+@inject NavigationManager NavManager
+@inject AppData AData
+@inject IJSRuntime JsRuntime
+@implements IDisposable
+
+@code {
+    private const int MaxPinned = 4;
+
+    private string CurrentPath
+    {
+        get
+        {
+            var rel = NavManager.ToBaseRelativePath(NavManager.Uri).TrimEnd('/').ToLowerInvariant();
+            var q = rel.IndexOf('?');
+            if (q >= 0) rel = rel[..q];
+            return rel;
+        }
+    }
+
+    private bool IsHome => string.IsNullOrEmpty(CurrentPath);
+    private bool IsSettingsRoute => CurrentPath.Equals("settings", StringComparison.OrdinalIgnoreCase);
+    private bool IsPlatformsRoute => CurrentPath.Equals("platforms", StringComparison.OrdinalIgnoreCase);
+    private bool HideSidebar => CurrentPath.Equals("welcome", StringComparison.OrdinalIgnoreCase);
+
+    private List<string> AllPlatforms() => AData.SortedPlatformListHandleDisabled();
+
+    private List<string> Pinned() => AllPlatforms().Take(MaxPinned).ToList();
+
+    private bool IsPlatformActive(string platform)
+    {
+        if (string.Equals(platform, "Steam", StringComparison.OrdinalIgnoreCase))
+            return CurrentPath.StartsWith("steam", StringComparison.OrdinalIgnoreCase);
+
+        // All non-Steam platforms route through /Basic/ — match by current platform safe-name.
+        if (!CurrentPath.StartsWith("basic", StringComparison.OrdinalIgnoreCase)) return false;
+        return string.Equals(CurrentPlatform.SafeName,
+            BasicPlatforms.PlatformSafeName(platform),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void NavigateToPlatform(string platform)
+    {
+        if (string.Equals(platform, "Steam", StringComparison.OrdinalIgnoreCase))
+        {
+            NavManager.NavigateTo("/Steam/");
+            return;
+        }
+
+        if (BasicPlatforms.PlatformExistsFromShort(platform))
+        {
+            BasicPlatforms.SetCurrentPlatformFromShort(platform);
+            NavManager.NavigateTo("/Basic/");
+        }
+    }
+
+    private string PlatformTileClass(string platform) =>
+        "p-" + BasicPlatforms.PlatformSafeName(platform).Replace(' ', '-');
+
+    private string PlatformLetter(string platform)
+    {
+        var name = BasicPlatforms.PlatformFullName(platform);
+        return string.IsNullOrEmpty(name) ? "?" : name[0].ToString().ToUpperInvariant();
+    }
+
+    private bool PlatformSvgExists(string platform) =>
+        File.Exists(Path.Join(Globals.UserDataFolder, $"wwwroot/img/platform/{BasicPlatforms.PlatformSafeName(platform)}.svg"));
+
+    private string PlatformSvgUseHref(string platform) =>
+        $"img/platform/{BasicPlatforms.PlatformSafeName(platform)}.svg#FG";
+
+    private void OnLocationChanged(object sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs args)
+        => InvokeAsync(StateHasChanged);
+
+    protected override void OnInitialized()
+    {
+        NavManager.LocationChanged += OnLocationChanged;
+    }
+
+    public void Dispose()
+    {
+        NavManager.LocationChanged -= OnLocationChanged;
+    }
+}
+
+@if (!HideSidebar)
+{
+<div class="m-sidebar">
+    <div class="m-sb-brand">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <rect x="2" y="2" width="20" height="20" rx="5" fill="var(--m-accent)" />
+            <path d="M7 9h10M12 9v8" stroke="#fff" stroke-width="2.4" stroke-linecap="round" />
+        </svg>
+        <span class="m-sb-brand-name">TcNo</span>
+        <span class="m-sb-version">v@(Globals.Version)</span>
+    </div>
+
+    <div class="m-eyebrow">Library</div>
+    <div class="m-sb-item @(IsHome ? "active" : "")" @onclick="@(() => NavManager.NavigateTo("/"))">
+        <svg class="m-glyph" viewBox="0 0 16 16">
+            <rect x="2" y="2" width="5" height="5" rx="1"></rect>
+            <rect x="9" y="2" width="5" height="5" rx="1"></rect>
+            <rect x="2" y="9" width="5" height="5" rx="1"></rect>
+            <rect x="9" y="9" width="5" height="5" rx="1"></rect>
+        </svg>
+        All platforms
+        <span class="m-sb-count">@AllPlatforms().Count</span>
+    </div>
+
+    @{
+        var pinned = Pinned();
+    }
+    @if (pinned.Count > 0)
+    {
+        <div class="m-eyebrow" style="margin-top: 14px;">Pinned</div>
+        @foreach (var platform in pinned)
+        {
+            var fullName = BasicPlatforms.PlatformFullName(platform);
+            var active = IsPlatformActive(platform);
+            <div class="m-sb-item @(active ? "active" : "")" @onclick="() => NavigateToPlatform(platform)">
+                <span class="m-sb-platform-glyph @PlatformTileClass(platform)">
+                    @if (PlatformSvgExists(platform))
+                    {
+                        <svg viewBox="0 0 500 500" preserveAspectRatio="xMidYMid meet">
+                            <use href="@PlatformSvgUseHref(platform)" class="ico-fg"></use>
+                        </svg>
+                    }
+                    else
+                    {
+                        <span style="font-size: 9px; font-weight: 700;">@PlatformLetter(platform)</span>
+                    }
+                </span>
+                @fullName
+            </div>
+        }
+    }
+
+    <div class="m-sb-spacer"></div>
+
+    <div class="m-sb-foot">
+        <div class="m-sb-item @(IsPlatformsRoute ? "active" : "")" @onclick="@(() => NavManager.NavigateTo("/Platforms"))">
+            <svg class="m-glyph" viewBox="0 0 16 16">
+                <path d="M3 4h10M3 8h10M3 12h10"></path>
+            </svg>
+            Manage platforms
+        </div>
+        <div class="m-sb-item @(IsSettingsRoute ? "active" : "")" @onclick="@(() => NavManager.NavigateTo("/Settings"))">
+            <svg class="m-glyph" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="2"></circle>
+                <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3 3l1.4 1.4M11.6 11.6L13 13M3 13l1.4-1.4M11.6 4.4L13 3"></path>
+            </svg>
+            Settings
+        </div>
+        <div class="m-sb-item" @onclick="@(() => JsRuntime.InvokeVoidAsync("showModal", "info"))">
+            <svg class="m-glyph" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="6"></circle>
+                <path d="M6.5 6.5a1.5 1.5 0 113 0c0 1-1.5 1.2-1.5 2.5"></path>
+                <circle cx="8" cy="11.5" r=".5" fill="currentColor" stroke="none"></circle>
+            </svg>
+            Help
+        </div>
+    </div>
+</div>
+}

--- a/TcNo-Acc-Switcher-Server/wwwroot/css/modern.css
+++ b/TcNo-Acc-Switcher-Server/wwwroot/css/modern.css
@@ -1,0 +1,941 @@
+/* TcNo Modern UI — Direction A
+   Layered on top of existing site.css / acclist.css. Reuses --accent/--accentHS/--accentL
+   from accent.css so the user's runtime accent picker keeps working. */
+
+:root {
+  --m-bg-0: #0a0b0f;
+  --m-bg-1: #0e1015;
+  --m-bg-2: #14171f;
+  --m-bg-3: #1a1d27;
+  --m-bg-4: #232733;
+  --m-line: #262a36;
+  --m-line-2: #2f3441;
+  --m-text-0: #f4f5f8;
+  --m-text-1: #c8ccd6;
+  --m-text-2: #8b909c;
+  --m-text-3: #5a5f6b;
+
+  --m-accent: var(--accent);
+  --m-accent-2: hsl(var(--accentHS), calc(var(--accentL) + 8%));
+  --m-accent-glow: hsla(var(--accentHS), var(--accentL), 0.40);
+  --m-accent-soft: hsla(var(--accentHS), var(--accentL), 0.18);
+
+  --m-success: #3ec491;
+  --m-warn: #f5b04a;
+  --m-danger: #ef5e6e;
+
+  --m-r-sm: 6px;
+  --m-r-md: 10px;
+  --m-r-lg: 14px;
+}
+
+/* Base body — keep the existing dark gradient but switch font stack and surface */
+html.modern-active body,
+body.modern-active {
+  font-family: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  background: var(--m-bg-0) !important;
+  color: var(--m-text-0);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* programMain becomes the flex shell host (sidebar + content) */
+.modern-active .programMain {
+  background: var(--m-bg-1) !important;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+.modern-active .programMain > .app-shell {
+  flex: 1; min-height: 0;
+}
+
+/* Soften the existing custom titlebar to match modern surface */
+.modern-active .headerbar {
+  background: linear-gradient(180deg, #1a1d27 0%, #14171f 100%) !important;
+  border-bottom: 1px solid var(--m-line);
+  height: 36px;
+}
+.modern-active #window-title {
+  font-family: inherit;
+}
+.modern-active #window-title > span {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--m-text-2);
+}
+.modern-active .header_icon {
+  height: 12px;
+  margin: 12px 8px;
+  fill: var(--m-text-1);
+}
+
+/* ========== App shell (sidebar + content) ========== */
+.app-shell {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+/* ========== Sidebar ========== */
+.m-sidebar {
+  width: 224px;
+  background: #0c0e13;
+  border-right: 1px solid var(--m-line);
+  display: flex;
+  flex-direction: column;
+  padding: 14px 10px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--m-line-2) transparent;
+}
+.m-sidebar::-webkit-scrollbar { width: 6px; }
+.m-sidebar::-webkit-scrollbar-thumb { background: var(--m-line-2); border-radius: 3px; }
+
+.m-sb-brand {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 10px 16px;
+}
+.m-sb-brand-name { font-weight: 600; font-size: 14px; color: var(--m-text-0); }
+.m-sb-version { font-size: 10px; color: var(--m-text-3); margin-left: auto; }
+
+.m-eyebrow {
+  font-size: 10.5px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--m-text-3);
+  padding: 4px 10px 6px;
+}
+
+.m-sb-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: 8px;
+  font-size: 13px; color: var(--m-text-1);
+  cursor: pointer; user-select: none;
+  transition: background .12s ease;
+  text-decoration: none;
+}
+.m-sb-item:hover { background: rgba(255,255,255,.03); color: var(--m-text-0); }
+.m-sb-item.active {
+  background: var(--m-bg-3);
+  color: var(--m-text-0);
+  font-weight: 500;
+}
+.m-sb-item.active .m-sb-count { color: var(--m-accent-2); }
+.m-sb-count {
+  margin-left: auto; color: var(--m-text-3);
+  font-size: 11px; font-variant-numeric: tabular-nums;
+}
+.m-sb-spacer { flex: 1; min-height: 14px; }
+.m-sb-foot { border-top: 1px solid var(--m-line); padding-top: 10px; }
+
+.m-sb-platform-glyph {
+  width: 18px; height: 18px; border-radius: 5px;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0; overflow: hidden;
+  background: var(--m-bg-3);
+}
+.m-sb-platform-glyph svg,
+.m-sb-platform-glyph img { width: 14px; height: 14px; display: block; }
+.m-sb-platform-glyph .ico-fg { fill: currentColor; }
+
+/* ========== Content area ========== */
+.m-content {
+  flex: 1; display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+  overflow: auto;
+}
+
+.m-content-header {
+  padding: 14px 28px 18px;
+  border-bottom: 1px solid var(--m-line);
+  display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0; gap: 16px;
+}
+.m-content-title {
+  font-size: 22px; font-weight: 600; letter-spacing: -0.3px;
+  color: var(--m-text-0);
+}
+.m-content-sub {
+  color: var(--m-text-2); font-size: 12.5px; margin-top: 2px;
+}
+
+.m-content-body {
+  flex: 1; overflow: auto; padding: 20px 28px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--m-line-2) transparent;
+}
+.m-content-body::-webkit-scrollbar { width: 8px; }
+.m-content-body::-webkit-scrollbar-thumb { background: var(--m-line-2); border-radius: 4px; }
+
+/* ========== Buttons (modern variant — namespaced to avoid clobbering existing) ========== */
+.m-btn {
+  font: inherit; font-size: 13px; font-weight: 500;
+  padding: 7px 12px; border-radius: 8px;
+  border: 1px solid var(--m-line-2);
+  background: var(--m-bg-3); color: var(--m-text-0);
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  line-height: 1;
+  transition: background .12s ease, transform .12s ease;
+  text-decoration: none;
+}
+.m-btn:hover { background: var(--m-bg-4); }
+.m-btn:active { transform: translateY(1px); }
+.m-btn.m-btn-primary {
+  background: var(--m-accent);
+  border-color: rgba(255,255,255,.12);
+  color: white;
+}
+.m-btn.m-btn-primary:hover { background: var(--m-accent-2); }
+.m-btn.m-btn-ghost {
+  background: transparent; border-color: transparent; color: var(--m-text-1);
+}
+.m-btn.m-btn-ghost:hover { background: rgba(255,255,255,.04); color: var(--m-text-0); }
+.m-btn.m-btn-sm { font-size: 12px; padding: 5px 9px; }
+.m-btn.m-btn-icon { padding: 6px; }
+
+/* ========== Active "currently signed in" banner ========== */
+.m-active-banner {
+  margin: 16px 28px 0;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: linear-gradient(90deg, var(--m-accent-soft), transparent);
+  border: 1px solid var(--m-accent-glow);
+  display: flex; align-items: center; gap: 14px;
+}
+.m-active-banner-eyebrow {
+  font-size: 10.5px; color: var(--m-accent-2);
+  font-weight: 600; letter-spacing: 0.08em;
+}
+.m-active-banner-name {
+  font-size: 14px; font-weight: 500; margin-top: 2px;
+  color: var(--m-text-0);
+}
+.m-active-banner-meta { color: var(--m-text-3); font-weight: 400; }
+
+/* ========== Platform tile (used in banner + cards) ========== */
+.m-tile {
+  border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  position: relative; cursor: pointer; flex-shrink: 0;
+  font-weight: 700; letter-spacing: -1px;
+  transition: transform .15s ease, box-shadow .15s ease;
+  background: var(--m-bg-3);
+  overflow: hidden;
+}
+.m-tile:hover { transform: translateY(-2px); }
+.m-tile.active {
+  box-shadow: 0 0 0 2px var(--m-accent), 0 8px 24px var(--m-accent-glow);
+}
+.m-tile svg { width: 60%; height: 60%; }
+.m-tile svg .ico-fg,
+.m-tile svg use { fill: currentColor; }
+.m-tile-text {
+  font-size: 14px; color: rgba(255,255,255,.92);
+  text-shadow: 0 1px 2px rgba(0,0,0,.35);
+}
+.m-tile-count {
+  position: absolute; top: 6px; right: 6px;
+  font-size: 10px; font-weight: 600;
+  background: rgba(0,0,0,.55);
+  padding: 2px 6px; border-radius: 99px;
+  color: #fff; letter-spacing: 0;
+}
+
+/* ========== Platform card grid (home page) ========== */
+.m-section-label {
+  display: flex; align-items: center;
+  margin-bottom: 10px; margin-top: 4px;
+}
+.m-section-label .m-eyebrow { padding: 0; }
+.m-section-label .m-right { margin-left: auto; }
+
+.m-home-cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 24px;
+}
+.m-home-cols.no-rail { grid-template-columns: 1fr; }
+@media (max-width: 920px) {
+  .m-home-cols { grid-template-columns: 1fr; }
+}
+
+.m-platform-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+.m-platform-card {
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line);
+  border-radius: 12px;
+  padding: 14px;
+  display: flex; flex-direction: column; gap: 10px;
+  cursor: pointer;
+  position: relative;
+  min-height: 132px;
+  transition: border-color .15s ease, transform .12s ease;
+  color: var(--m-text-0);
+}
+.m-platform-card:hover {
+  border-color: var(--m-line-2);
+  transform: translateY(-1px);
+}
+.m-platform-card.active { border-color: var(--m-accent-glow); }
+.m-platform-card-name { font-weight: 500; font-size: 13.5px; }
+.m-platform-card-count { font-size: 11.5px; color: var(--m-text-2); margin-top: 2px; }
+.m-platform-card-active-pill {
+  position: absolute; top: 12px; right: 12px;
+  font-size: 10px; font-weight: 600; color: var(--m-accent-2);
+  padding: 3px 7px; border-radius: 99px;
+  background: var(--m-accent-soft);
+  border: 1px solid var(--m-accent-glow);
+  letter-spacing: 0.04em;
+}
+.m-platform-card-current {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11.5px; color: var(--m-text-2); margin-top: 2px;
+  min-height: 18px;
+}
+.m-platform-card-current .m-name {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.m-platform-card-empty {
+  font-size: 11px; color: var(--m-text-3); margin-top: 2px; font-style: italic;
+}
+
+/* Platform-tile color schemes (matched to design) */
+.m-tile.p-Steam       { background: linear-gradient(135deg, #1b2838 0%, #2a475e 100%); color: #e6f0ff; }
+.m-tile.p-Epic-Games  { background: #1d1d1d; color: #fff; box-shadow: inset 0 0 0 1px #2a2a2a; }
+.m-tile.p-BattleNet   { background: linear-gradient(135deg, #00264a 0%, #0070b8 100%); color: #d6eaff; }
+.m-tile.p-Origin      { background: linear-gradient(135deg, #2a0d00 0%, #f56c2d 130%); color: #fff; }
+.m-tile.p-EA-Desktop  { background: linear-gradient(135deg, #1a1a1a 0%, #c81e1e 130%); color: #fff; }
+.m-tile.p-Riot-Games  { background: linear-gradient(135deg, #0a0a0a 0%, #d13639 130%); color: #fff; }
+.m-tile.p-Ubisoft     { background: linear-gradient(135deg, #001a2c 0%, #0083e3 130%); color: #fff; }
+.m-tile.p-Discord     { background: linear-gradient(135deg, #2c2f3f 0%, #5865f2 130%); color: #fff; }
+.m-tile.p-Discord-Canary { background: linear-gradient(135deg, #2a1f0a 0%, #f1aa14 130%); color: #fff; }
+.m-tile.p-Discord-PTB { background: linear-gradient(135deg, #19243a 0%, #4488df 130%); color: #fff; }
+.m-tile.p-Rockstar    { background: linear-gradient(135deg, #131313 0%, #fcaf17 160%); color: #fff; }
+.m-tile.p-GOG-Galaxy  { background: linear-gradient(135deg, #1a0a2a 0%, #b164ff 130%); color: #fff; }
+.m-tile.p-Genshin-Impact { background: linear-gradient(135deg, #2a1f0a 0%, #d49b3a 130%); color: #fff; }
+.m-tile.p-OBS-Studio  { background: #1c1c1d; color: #fff; }
+.m-tile.p-Honkai-StarRail { background: linear-gradient(135deg, #0a1730 0%, #4ea4ff 130%); color: #fff; }
+.m-tile.p-Albion-Online   { background: linear-gradient(135deg, #2a1f10 0%, #c98c4b 130%); color: #fff; }
+.m-tile.p-Escape-from-Tarkov { background: linear-gradient(135deg, #1a1810 0%, #595138 130%); color: #d8d2bb; }
+.m-tile.p-Magic-Arena { background: linear-gradient(135deg, #2a1100 0%, #fbb040 130%); color: #fff; }
+.m-tile.p-Jagex       { background: linear-gradient(135deg, #2a160c 0%, #bf4e2c 130%); color: #fff; }
+.m-tile.p-Oculus      { background: linear-gradient(135deg, #0a1422 0%, #1c8cff 130%); color: #fff; }
+.m-tile.p-PS-Remote-Play { background: linear-gradient(135deg, #0a1124 0%, #003791 130%); color: #fff; }
+.m-tile.p-GeForce-Now { background: linear-gradient(135deg, #0a1a06 0%, #76b900 130%); color: #fff; }
+.m-tile.p-Delta-Force-Hawk-Ops { background: linear-gradient(135deg, #1a1d10 0%, #5a7a3a 130%); color: #fff; }
+.m-tile.p-Arena-Breakout-Infinite { background: linear-gradient(135deg, #1a1d10 0%, #c0a35a 130%); color: #fff; }
+.m-tile.p-default     { background: linear-gradient(135deg, #1a1d27 0%, #2a3142 100%); color: #fff; }
+
+/* Avatar primitive */
+.m-avatar {
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+.m-avatar.square { border-radius: 22%; }
+.m-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+/* ========== Activity rail ========== */
+.m-activity-rail {
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line);
+  border-radius: 12px;
+  padding: 14px 0 4px;
+}
+.m-activity-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  font-size: 12px;
+}
+.m-activity-row + .m-activity-row { border-top: 1px solid var(--m-line); }
+.m-activity-row .m-activity-msg { flex: 1; color: var(--m-text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.m-activity-time {
+  color: var(--m-text-3); font-variant-numeric: tabular-nums; font-size: 11px;
+  flex-shrink: 0;
+}
+.m-activity-dot {
+  width: 8px; height: 8px; border-radius: 99px; flex-shrink: 0;
+  background: var(--m-accent);
+}
+.m-activity-empty {
+  padding: 18px 14px; font-size: 12px; color: var(--m-text-3); text-align: center;
+}
+
+/* ============================================================
+   Phase 2 — Per-platform switcher: density, notes, switch overlay
+   ============================================================ */
+
+/* ---- Platform page top header (replaces bottom action bar) ---- */
+.m-platform-header {
+  padding: 14px 28px 18px;
+  border-bottom: 1px solid var(--m-line);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; flex-shrink: 0;
+}
+.m-platform-header-left {
+  display: flex; align-items: center; gap: 14px; min-width: 0;
+}
+.m-platform-header-meta { min-width: 0; }
+.m-platform-header-title {
+  font-size: 22px; font-weight: 600; letter-spacing: -0.3px;
+  color: var(--m-text-0);
+  display: flex; align-items: center; gap: 10px;
+}
+.m-platform-header-sub {
+  color: var(--m-text-2); font-size: 12.5px; margin-top: 2px;
+}
+.m-platform-header-right {
+  display: flex; align-items: center; gap: 10px; flex-shrink: 0;
+}
+.m-search {
+  font: inherit; font-size: 12.5px; padding: 7px 10px; width: 180px;
+  background: var(--m-bg-2); color: var(--m-text-0);
+  border: 1px solid var(--m-line-2); border-radius: 8px; outline: none;
+}
+.m-search:focus { border-color: var(--m-accent); }
+.m-search::placeholder { color: var(--m-text-3); }
+
+/* ---- Density toggle (3 buttons) ---- */
+.m-density-toggle {
+  display: flex;
+  background: var(--m-bg-3);
+  border: 1px solid var(--m-line-2);
+  border-radius: 8px;
+  padding: 2px;
+}
+.m-density-btn {
+  padding: 5px 8px; border-radius: 6px; cursor: pointer;
+  color: var(--m-text-2);
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent; border: 0;
+}
+.m-density-btn:hover { color: var(--m-text-1); }
+.m-density-btn.active { background: var(--m-bg-4); color: var(--m-text-0); }
+
+/* ---- Account list — overrides existing acclist.css when modern density is set ---- */
+.modern-active .acc_list.m-density-tiles,
+.modern-active .acc_list.m-density-rows,
+.modern-active .acc_list.m-density-compact {
+  display: block;
+  background: transparent;
+  width: 100%;
+  height: auto;
+  padding: 16px 28px 28px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.modern-active .acc_list.m-density-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+  padding: 16px 28px 28px;
+}
+.modern-active .acc_list.m-density-rows {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.modern-active .acc_list.m-density-compact {
+  padding: 16px 28px 28px;
+}
+
+/* Hide the radio input itself; the label handles all interaction */
+.modern-active .acc_list.m-density-tiles .acc_list_item input.acc,
+.modern-active .acc_list.m-density-rows .acc_list_item input.acc,
+.modern-active .acc_list.m-density-compact .acc_list_item input.acc {
+  position: absolute; opacity: 0; pointer-events: none; width: 0; height: 0;
+}
+
+/* Make the item a flex shell that the label sits inside */
+.modern-active .acc_list.m-density-tiles .acc_list_item,
+.modern-active .acc_list.m-density-rows .acc_list_item,
+.modern-active .acc_list.m-density-compact .acc_list_item {
+  position: relative;
+  border: 0;
+  cursor: pointer;
+}
+.modern-active .acc_list.m-density-compact .acc_list_item + .acc_list_item label.acc {
+  border-top: 1px solid var(--m-line);
+}
+
+/* Per-density label styling */
+.modern-active .acc_list.m-density-tiles label.acc {
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line);
+  border-radius: 12px;
+  padding: 16px 14px 12px;
+  display: flex; flex-direction: column; align-items: center;
+  text-align: center; gap: 8px;
+  cursor: pointer; min-height: 0;
+  transition: border-color .15s ease, transform .12s ease;
+}
+.modern-active .acc_list.m-density-tiles label.acc:hover {
+  border-color: var(--m-line-2); transform: translateY(-1px);
+}
+.modern-active .acc_list.m-density-tiles label.acc img {
+  width: 56px; height: 56px; border-radius: 50%;
+  object-fit: cover; flex-shrink: 0;
+  margin: 0 auto;
+}
+.modern-active .acc_list.m-density-tiles label.acc h6.displayName {
+  font-weight: 500; font-size: 13.5px; margin: 0;
+  color: var(--m-text-0);
+}
+.modern-active .acc_list.m-density-tiles label.acc p {
+  font-size: 11px; color: var(--m-text-3); margin: 0;
+  line-height: 1.3;
+}
+
+.modern-active .acc_list.m-density-rows label.acc {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color .12s ease, background .12s ease;
+}
+.modern-active .acc_list.m-density-rows label.acc:hover {
+  background: var(--m-bg-3); border-color: var(--m-line-2);
+}
+.modern-active .acc_list.m-density-rows label.acc img {
+  width: 40px; height: 40px; border-radius: 50%; object-fit: cover; grid-row: span 2; grid-column: 1;
+}
+.modern-active .acc_list.m-density-rows label.acc h6.displayName {
+  font-weight: 500; font-size: 13.5px; margin: 0; grid-column: 2;
+  color: var(--m-text-0);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.modern-active .acc_list.m-density-rows label.acc p {
+  font-size: 11.5px; color: var(--m-text-3); margin: 0; grid-column: 2;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.modern-active .acc_list.m-density-rows label.acc .m-acct-actions {
+  grid-column: 3; grid-row: span 2;
+  display: flex; align-items: center; gap: 8px;
+}
+
+.modern-active .acc_list.m-density-compact .acc_list_item:first-child label.acc {
+  border-top: 1px solid var(--m-line);
+  border-radius: 10px 10px 0 0;
+}
+.modern-active .acc_list.m-density-compact .acc_list_item:last-child label.acc {
+  border-radius: 0 0 10px 10px;
+}
+.modern-active .acc_list.m-density-compact label.acc {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) 1fr 110px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  background: var(--m-bg-2);
+  border-left: 1px solid var(--m-line);
+  border-right: 1px solid var(--m-line);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.modern-active .acc_list.m-density-compact label.acc:hover {
+  background: var(--m-bg-3);
+}
+.modern-active .acc_list.m-density-compact label.acc img {
+  width: 26px; height: 26px; border-radius: 50%; object-fit: cover;
+}
+.modern-active .acc_list.m-density-compact label.acc h6.displayName {
+  font-weight: 500; font-size: 12.5px; margin: 0;
+  color: var(--m-text-0);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.modern-active .acc_list.m-density-compact label.acc p {
+  font-size: 11.5px; color: var(--m-text-2); margin: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.modern-active .acc_list.m-density-compact label.acc .m-acct-actions {
+  display: flex; align-items: center; justify-content: flex-end; gap: 8px;
+}
+
+/* "Switch" / Active-pill on each item (rows + compact) */
+.m-active-pill {
+  font-size: 11px; color: var(--m-success);
+  padding: 3px 8px; border-radius: 99px;
+  background: rgba(62,196,145,.12);
+  border: 1px solid rgba(62,196,145,.3);
+  display: inline-flex; align-items: center; gap: 5px;
+  white-space: nowrap;
+}
+.m-active-pill .m-dot {
+  width: 5px; height: 5px; border-radius: 99px; background: var(--m-success);
+}
+
+/* Active highlight (replaces JS-set .currentAcc styling for the modern theme) */
+.modern-active .acc_list.m-density-tiles label.currentAcc {
+  border-color: rgba(62,196,145,.45);
+  box-shadow: 0 0 0 1px rgba(62,196,145,.25);
+}
+.modern-active .acc_list.m-density-rows label.currentAcc,
+.modern-active .acc_list.m-density-compact label.currentAcc {
+  border-color: rgba(62,196,145,.45);
+}
+.modern-active label.currentAcc::after {
+  content: "";
+}
+
+/* Inline note pill / input on each item */
+.m-note {
+  font-size: 11px; color: var(--m-accent-2);
+  padding: 1px 6px; border-radius: 4px;
+  background: var(--m-accent-soft);
+  border: 1px solid var(--m-accent-glow);
+  max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: inline-block; cursor: text;
+}
+.m-note-add {
+  font-size: 11px; color: var(--m-text-3); cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+  background: transparent; border: 1px dashed transparent; padding: 1px 6px; border-radius: 4px;
+}
+.m-note-add:hover { color: var(--m-text-1); border-color: var(--m-line-2); }
+.m-note-input {
+  font: inherit; font-size: 12px; color: var(--m-text-0);
+  background: var(--m-bg-3);
+  border: 1px solid var(--m-line-2);
+  padding: 4px 8px;
+  border-radius: 6px;
+  outline: none;
+  max-width: 220px;
+}
+.m-note-input:focus { border-color: var(--m-accent); }
+
+/* Tag chips for level/VAC/etc. */
+.m-tag {
+  font-size: 11px;
+  padding: 1px 6px; border-radius: 4px;
+  background: var(--m-bg-3);
+  color: var(--m-text-2);
+}
+.m-tag.danger { color: var(--m-danger); background: rgba(239,94,110,.1); }
+
+/* ---- Switch overlay ---- */
+.m-switch-overlay {
+  position: fixed; inset: 0;
+  background: rgba(6,7,10,.78);
+  backdrop-filter: blur(6px);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+  animation: m-fade-in .2s ease both;
+}
+.m-switch-card {
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line-2);
+  padding: 24px 28px;
+  border-radius: 14px;
+  display: flex; align-items: center; gap: 18px;
+  min-width: 360px;
+  box-shadow: 0 30px 80px rgba(0,0,0,.5);
+  color: var(--m-text-0);
+}
+.m-switch-eyebrow {
+  font-size: 11.5px; color: var(--m-text-3);
+  letter-spacing: 0.04em; font-weight: 600;
+}
+.m-switch-name {
+  font-size: 15px; font-weight: 500; margin-top: 4px;
+}
+.m-switch-name .m-accent { color: var(--m-accent-2); }
+.m-spinner {
+  width: 36px; height: 36px; border-radius: 50%;
+  border: 2.5px solid var(--m-bg-4);
+  border-top-color: var(--m-accent);
+  animation: m-spin .9s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes m-spin { to { transform: rotate(360deg); } }
+@keyframes m-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Empty state for filtered account list */
+.m-empty-state {
+  padding: 40px;
+  text-align: center;
+  color: var(--m-text-3);
+  font-size: 13px;
+}
+
+/* ============================================================
+   Phase 3 — Settings (sectioned nav) + Onboarding
+   ============================================================ */
+
+/* ---- Settings sectioned shell ---- */
+.m-set-shell {
+  flex: 1; display: flex; overflow: hidden; min-height: 0;
+}
+.m-set-nav {
+  width: 180px;
+  border-right: 1px solid var(--m-line);
+  padding: 18px 8px;
+  flex-shrink: 0;
+  background: transparent;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--m-line-2) transparent;
+}
+.m-set-nav-item {
+  padding: 7px 12px; border-radius: 6px;
+  font-size: 13px; color: var(--m-text-1);
+  cursor: pointer;
+  margin-bottom: 2px;
+  user-select: none;
+}
+.m-set-nav-item:hover { background: rgba(255,255,255,.03); color: var(--m-text-0); }
+.m-set-nav-item.active { background: var(--m-bg-3); color: var(--m-text-0); }
+
+.m-set-pane {
+  flex: 1; padding: 22px 28px; overflow: auto; min-width: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--m-line-2) transparent;
+}
+.m-set-pane::-webkit-scrollbar { width: 8px; }
+.m-set-pane::-webkit-scrollbar-thumb { background: var(--m-line-2); border-radius: 4px; }
+
+.m-set-section { margin-bottom: 28px; scroll-margin-top: 12px; }
+.m-set-section-title {
+  font-size: 11px; color: var(--m-text-3); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  padding: 0 0 12px;
+}
+
+/* ---- Modern overrides for the existing SharedSettings markup ---- */
+.modern-active .SettingsHeader {
+  font-size: 11px !important; color: var(--m-text-3) !important; font-weight: 600 !important;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  padding: 18px 0 10px !important;
+  margin: 0 !important;
+  border-bottom: 1px solid var(--m-line);
+}
+.modern-active h1.SettingsHeader {
+  font-size: 20px !important; color: var(--m-text-0) !important;
+  text-transform: none; letter-spacing: -0.3px; font-weight: 600 !important;
+  border-bottom: none;
+  padding: 4px 0 16px !important;
+}
+.modern-active .rowSetting {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--m-line);
+  color: var(--m-text-1);
+  font-size: 13px;
+}
+.modern-active .rowSetting:last-child { border-bottom: none; }
+.modern-active .rowSetting label { color: var(--m-text-1); cursor: pointer; }
+
+/* Custom toggle styling for Bootstrap form-check inside settings */
+.modern-active .rowSetting .form-check {
+  display: inline-flex; align-items: center; padding: 0;
+  margin: 0;
+}
+.modern-active .rowSetting .form-check-input {
+  appearance: none; -webkit-appearance: none;
+  width: 36px; height: 20px; border-radius: 99px;
+  background: var(--m-bg-4) !important;
+  border: 1px solid var(--m-line-2) !important;
+  position: relative; cursor: pointer;
+  transition: background .2s;
+  margin: 0 8px 0 0;
+}
+.modern-active .rowSetting .form-check-input:checked {
+  background: var(--m-accent) !important;
+  border-color: rgba(255,255,255,.15) !important;
+}
+.modern-active .rowSetting .form-check-input::after {
+  content: "";
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: white;
+  position: absolute; top: 2px; left: 2px;
+  transition: left .2s;
+}
+.modern-active .rowSetting .form-check-input:checked::after { left: 19px; }
+.modern-active .rowSetting .form-check-label { display: none; }
+
+/* Bootstrap dropdown inside settings - keep functional, restyle subtly */
+.modern-active .rowDropdown { margin-top: 4px; }
+.modern-active .rowSetting .dropdown-toggle {
+  font: inherit; font-size: 13px; padding: 6px 12px; border-radius: 8px;
+  border: 1px solid var(--m-line-2);
+  background: var(--m-bg-3);
+  color: var(--m-text-0);
+}
+
+.modern-active .settingsCol {
+  background: transparent;
+  padding: 0 !important;
+}
+.modern-active .container.mainblock {
+  background: transparent;
+  max-width: none; padding: 0;
+}
+
+/* The Settings page's own bottom Close button */
+.modern-active .buttoncol.col_close {
+  padding: 16px 0;
+  display: flex; justify-content: flex-end;
+  border-top: 1px solid var(--m-line);
+  margin-top: 18px;
+}
+.modern-active .btn_close {
+  font: inherit; font-size: 13px; font-weight: 500;
+  padding: 7px 14px; border-radius: 8px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: var(--m-accent); color: white;
+  cursor: pointer;
+}
+.modern-active .btn_close:hover {
+  background: var(--m-accent-2);
+}
+
+/* ---- Onboarding ---- */
+.m-onb-shell {
+  flex: 1; display: flex; flex-direction: column; min-height: 0;
+}
+.m-onb-topbar {
+  padding: 16px 28px;
+  display: flex; align-items: center;
+  border-bottom: 1px solid var(--m-line);
+  flex-shrink: 0;
+}
+.m-onb-topbar-name {
+  font-weight: 600; font-size: 13.5px; color: var(--m-text-0);
+}
+.m-onb-step-dots { display: flex; gap: 6px; margin-left: auto; }
+.m-onb-dot {
+  width: 24px; height: 4px; border-radius: 2px;
+  background: var(--m-bg-4);
+  transition: background .2s;
+}
+.m-onb-dot.done { background: var(--m-accent); }
+.m-onb-dot.active { background: var(--m-accent); box-shadow: 0 0 8px var(--m-accent-glow); }
+
+.m-onb-body {
+  flex: 1; overflow: auto; padding: 24px 28px;
+  scrollbar-width: thin; scrollbar-color: var(--m-line-2) transparent;
+}
+.m-onb-footer {
+  padding: 12px 28px;
+  border-top: 1px solid var(--m-line);
+  display: flex; align-items: center; gap: 12px;
+  flex-shrink: 0;
+}
+.m-onb-spacer { flex: 1; }
+
+.m-onb-welcome {
+  max-width: 560px; margin: 30px auto; text-align: center;
+}
+.m-onb-welcome-mark {
+  display: inline-flex; padding: 18px; border-radius: 20px;
+  background: var(--m-accent-soft); border: 1px solid var(--m-accent-glow);
+  margin-bottom: 22px;
+}
+.m-onb-welcome-title {
+  font-size: 26px; font-weight: 600; letter-spacing: -0.5px;
+  color: var(--m-text-0);
+}
+.m-onb-welcome-sub {
+  color: var(--m-text-2); font-size: 14px; line-height: 1.55;
+  margin: 12px auto 0; max-width: 460px;
+}
+.m-onb-welcome-tiles {
+  display: flex; gap: 10px; justify-content: center;
+  margin-top: 26px; flex-wrap: wrap;
+}
+
+.m-onb-detect {
+  max-width: 720px; margin: 10px auto;
+}
+.m-onb-detect-title {
+  font-size: 20px; font-weight: 600; letter-spacing: -0.3px;
+  color: var(--m-text-0);
+}
+.m-onb-detect-sub {
+  color: var(--m-text-2); font-size: 13px;
+  margin-top: 6px; margin-bottom: 22px;
+}
+.m-onb-detect-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
+.m-onb-detect-item {
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-accent-glow);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex; align-items: center; gap: 12px;
+  color: var(--m-text-0);
+}
+.m-onb-detect-item.skip {
+  background: transparent; border-color: var(--m-line); opacity: 0.55;
+}
+.m-onb-detect-item-name {
+  font-weight: 500; font-size: 12.5px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.m-onb-detect-item-status {
+  font-size: 10.5px; color: var(--m-success);
+}
+.m-onb-detect-item.skip .m-onb-detect-item-status { color: var(--m-text-3); }
+
+.m-onb-hotkey {
+  max-width: 560px; margin: 30px auto; text-align: center;
+}
+.m-onb-hotkey-title {
+  font-size: 22px; font-weight: 600; letter-spacing: -0.3px;
+  color: var(--m-text-0);
+}
+.m-onb-hotkey-sub {
+  color: var(--m-text-2); font-size: 13px;
+  margin: 8px 0 28px;
+}
+.m-onb-hotkey-display {
+  display: inline-flex; gap: 8px;
+  padding: 20px 28px;
+  background: var(--m-bg-2);
+  border: 1px solid var(--m-line);
+  border-radius: 14px;
+}
+.m-kbd {
+  padding: 3px 8px; font-size: 11.5px; font-weight: 500;
+  background: var(--m-bg-3);
+  border: 1px solid var(--m-line-2);
+  border-radius: 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  box-shadow: 0 1px 0 var(--m-line-2);
+  color: var(--m-text-0);
+}
+
+/* When onboarding is the active route, hide the sidebar to keep the focus */
+.modern-active.onboarding .m-sidebar { display: none; }
+
+/* ========== Inline glyphs (stroke-icon shim — used in sidebar) ========== */
+.m-glyph {
+  width: 14px; height: 14px; flex-shrink: 0; display: block;
+  stroke: currentColor; stroke-width: 1.6; fill: none;
+  stroke-linecap: round; stroke-linejoin: round;
+}
+.m-glyph-fill { fill: currentColor; stroke: none; }

--- a/TcNo-Acc-Switcher-Server/wwwroot/js/modern.js
+++ b/TcNo-Acc-Switcher-Server/wwwroot/js/modern.js
@@ -1,0 +1,137 @@
+// TcNo Modern UI helpers — Phase 2
+// Wraps the existing JS contracts (swapTo / Set*Notes / getCurrentPage) so the new UI can
+// trigger account swaps and inline note saves without going through the legacy modals.
+
+(function () {
+    "use strict";
+
+    function currentPlatformPage() {
+        // getCurrentPage() is defined in WebFuncs.js — returns "Steam", "Basic", etc.
+        if (typeof getCurrentPage === "function") {
+            const p = getCurrentPage();
+            if (p === "Steam" || p === "Basic") return p;
+        }
+        return null;
+    }
+
+    // ---------------- Switch overlay ----------------
+    function ensureOverlay() {
+        let el = document.getElementById("m-switch-overlay");
+        if (el) return el;
+        el = document.createElement("div");
+        el.id = "m-switch-overlay";
+        el.className = "m-switch-overlay";
+        el.style.display = "none";
+        el.innerHTML =
+            '<div class="m-switch-card">' +
+              '<div class="m-spinner"></div>' +
+              '<div>' +
+                '<div class="m-switch-eyebrow" id="m-switch-eyebrow">SWITCHING</div>' +
+                '<div class="m-switch-name">Signing in as <span class="m-accent" id="m-switch-name">…</span></div>' +
+              '</div>' +
+            '</div>';
+        document.body.appendChild(el);
+        return el;
+    }
+
+    window.tcnoShowSwitchOverlay = function (displayName, platformLabel) {
+        const el = ensureOverlay();
+        const eyebrow = document.getElementById("m-switch-eyebrow");
+        const name = document.getElementById("m-switch-name");
+        if (eyebrow) eyebrow.textContent = (platformLabel || currentPlatformPage() || "SWITCHING").toUpperCase();
+        if (name) name.textContent = displayName || "…";
+        el.style.display = "flex";
+    };
+
+    window.tcnoHideSwitchOverlay = function () {
+        const el = document.getElementById("m-switch-overlay");
+        if (el) el.style.display = "none";
+    };
+
+    // ---------------- Switch action ----------------
+    // Selects the account's hidden radio (so getSelected() in WebFuncs.js sees it),
+    // shows the overlay, then defers to the existing swapTo() pipeline.
+    window.tcnoSwitchAccount = function (accId, displayName, ev) {
+        if (ev && typeof ev.preventDefault === "function") ev.preventDefault();
+        if (ev && typeof ev.stopPropagation === "function") ev.stopPropagation();
+
+        const radio = document.getElementById(accId);
+        if (radio) {
+            radio.checked = true;
+            try { if (typeof selectedItemChanged === "function") selectedItemChanged(); } catch (e) { /* noop */ }
+        }
+
+        window.tcnoShowSwitchOverlay(displayName);
+
+        // Failsafe — if swapTo never resolves, hide the overlay so the user isn't stuck.
+        const failsafe = setTimeout(window.tcnoHideSwitchOverlay, 12000);
+
+        try {
+            if (typeof swapTo === "function") {
+                Promise.resolve(swapTo(-1, null))
+                    .catch(function () { /* noop */ })
+                    .finally(function () {
+                        clearTimeout(failsafe);
+                        // Hold the overlay briefly so the animation reads, then hide.
+                        setTimeout(window.tcnoHideSwitchOverlay, 600);
+                    });
+            } else {
+                clearTimeout(failsafe);
+                window.tcnoHideSwitchOverlay();
+            }
+        } catch (e) {
+            clearTimeout(failsafe);
+            window.tcnoHideSwitchOverlay();
+        }
+    };
+
+    // Wraps the existing "Login as selected" button so it shows the overlay.
+    window.tcnoSwitchSelected = function (ev) {
+        if (ev && typeof ev.preventDefault === "function") ev.preventDefault();
+        const radio = document.querySelector("input.acc:checked");
+        if (!radio) {
+            // Fall through to existing swapTo so it can show its own "select an account" toast.
+            if (typeof swapTo === "function") swapTo(-1, ev);
+            return;
+        }
+        const label = document.querySelector('label[for="' + radio.id + '"] .displayName, label[for="' + radio.id + '"] h6.displayName');
+        const name = (label && label.textContent) ? label.textContent.trim() : "selected account";
+        window.tcnoSwitchAccount(radio.id, name, ev);
+    };
+
+    // ---------------- Inline note save ----------------
+    window.tcnoSaveNote = async function (accId, note) {
+        const platform = currentPlatformPage();
+        if (!platform || typeof DotNet === "undefined") return;
+        try {
+            await DotNet.invokeMethodAsync("TcNo-Acc-Switcher-Server", "Set" + platform + "Notes", accId, note || "");
+        } catch (e) {
+            console.error("tcnoSaveNote failed:", e);
+        }
+    };
+
+    // ---------------- Settings-pane scroll-to-section ----------------
+    // The legacy SharedSettings emits <h2 class="SettingsHeader"> per section. We map our
+    // nav ids to the index of that <h2> within the pane and scroll to it.
+    const SECTION_INDEX = {
+        language: 0, theme: 1, system: 2, program: 3, statssharing: 4
+    };
+    window.tcnoScrollSettingsTo = function (sectionId) {
+        const pane = document.getElementById("set-pane");
+        if (!pane) return;
+        const headers = pane.querySelectorAll("h2.SettingsHeader");
+        const idx = SECTION_INDEX[sectionId];
+        if (idx === undefined || idx >= headers.length) return;
+        headers[idx].scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    // ---------------- Density toggle persistence ----------------
+    const DENSITY_KEY = "tcno.modern.density";
+    window.tcnoGetDensity = function () {
+        try { return localStorage.getItem(DENSITY_KEY) || "tiles"; }
+        catch (e) { return "tiles"; }
+    };
+    window.tcnoSetDensity = function (density) {
+        try { localStorage.setItem(DENSITY_KEY, density); } catch (e) { /* noop */ }
+    };
+})();


### PR DESCRIPTION
… settings, onboarding

Layered modern.css/.js on top of the existing Blazor app so the design works without ripping out current functionality. New body class .modern-active activates everything.

Phase 1 — App shell + home
- modern.css design tokens, sidebar, content header, platform card grid, activity rail
- Sidebar.razor (Library / Pinned platforms / Settings / Help)
- MainLayout wraps @Body in app-shell + Sidebar
- Index.razor replaces SVG-tile grid with platform cards + counts (PlatformAccountCounts disk-walk, 5s cache)

Phase 2 — Per-platform switcher
- AccountList accepts Density (tiles/rows/compact) + Filter; cascades to AccountItem
- AccountItem keeps radio+label structure (preserves swapTo / highlightCurrentAccount JS) but adds inline-editable note and Switch button on rows/compact
- Steam/Basic Index pages get a top header (back, tile, name+count, search, density toggle, +Add, Login)
- modern.js: tcnoSwitchAccount wraps swapTo with full-screen spinner overlay, tcnoSaveNote skips the legacy modal+reload, density persists in localStorage

Phase 3 — Settings + onboarding
- Settings.razor wraps SharedSettings in a sectioned-nav shell (anchor scroll into existing h2 headers)
- Modern overrides for .SettingsHeader / .rowSetting / Bootstrap form-check toggles
- Welcome.razor: 3-step first-launch flow, gated by .onboarded marker in UserDataFolder
- Sidebar hides itself on /Welcome