### PR TITLE
[codex] Fix tray startup and menu stability

### DIFF
--- a/TcNo-Acc-Switcher-Client/App.xaml.cs
+++ b/TcNo-Acc-Switcher-Client/App.xaml.cs
@@ -179,6 +179,7 @@ namespace TcNo_Acc_Switcher_Client
             {
                 var mainWindow = new MainWindow();
                 mainWindow.Show();
+                StartTrayForTrayMode();
             }
             catch (FileNotFoundException ex)
             {
@@ -200,6 +201,12 @@ namespace TcNo_Acc_Switcher_Client
 
             AppStats.CrashCount++;
             AppStats.SaveSettings();
+        }
+
+        private static void StartTrayForTrayMode()
+        {
+            if (!AppSettings.TrayStartup && !AppSettings.TrayMinimizeNotExit) return;
+            _ = NativeFuncs.StartTrayIfNotRunning();
         }
 
         /// <summary>

--- a/TcNo-Acc-Switcher-Client/MainWindow.xaml.cs
+++ b/TcNo-Acc-Switcher-Client/MainWindow.xaml.cs
@@ -48,7 +48,7 @@ namespace TcNo_Acc_Switcher_Client
     {
         private static readonly Thread Server = new(RunServer);
         private static string _address = "";
-        private readonly string _mainBrowser = AppSettings.ActiveBrowser; // <CEF/WebView>
+        private string _mainBrowser = AppSettings.ActiveBrowser; // <CEF/WebView>
 
         private static void RunServer()
         {
@@ -159,7 +159,7 @@ namespace TcNo_Acc_Switcher_Client
                     }
 
                     // Verify CEF is initialized before creating browser
-                    if (!Cef.IsInitialized)
+                    if (Cef.IsInitialized != true)
                     {
                         Globals.WriteToLog("CEF initialization completed but Cef.IsInitialized is false. Switching to WebView2.");
                         AppSettings.ActiveBrowser = "WebView";
@@ -259,7 +259,7 @@ namespace TcNo_Acc_Switcher_Client
             Globals.DebugWriteLine(@"[Func:(Client-CEF)MainWindow.xaml.cs.InitializeChromium]");
             
             // Check if CEF is already initialized
-            if (Cef.IsInitialized)
+            if (Cef.IsInitialized == true)
             {
                 return true;
             }
@@ -279,7 +279,7 @@ namespace TcNo_Acc_Switcher_Client
                 Cef.Initialize(settings);
                 
                 // Verify initialization succeeded
-                if (!Cef.IsInitialized)
+                if (Cef.IsInitialized != true)
                 {
                     Globals.WriteToLog("CEF.Initialize() completed but Cef.IsInitialized is false.");
                     return false;

--- a/TcNo-Acc-Switcher-Globals/Tray.cs
+++ b/TcNo-Acc-Switcher-Globals/Tray.cs
@@ -59,6 +59,14 @@ namespace TcNo_Acc_Switcher_Globals
             TrayUser.RemoveUserByArg(ref trayUsers, platform, arg);
             TrayUser.SaveUsers(trayUsers);
         }
+
+        public static void UpdateTrayUserNameByArg(string platform, string arg, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return;
+            var trayUsers = TrayUser.ReadTrayUsers();
+            if (!TrayUser.UpdateUserNameByArg(ref trayUsers, platform, arg, name)) return;
+            TrayUser.SaveUsers(trayUsers);
+        }
         #endregion
     }
     public class TrayUser
@@ -135,6 +143,15 @@ namespace TcNo_Acc_Switcher_Globals
             {
                 _ = trayUsers[platform].Remove(tu);
             }
+        }
+
+        public static bool UpdateUserNameByArg(ref Dictionary<string, List<TrayUser>> trayUsers, string platform, string arg, string name)
+        {
+            if (!trayUsers.ContainsKey(platform)) return false;
+            var user = trayUsers[platform].FirstOrDefault(x => x.Arg == arg);
+            if (user == null || user.Name == name) return false;
+            user.Name = name;
+            return true;
         }
 
         /// <summary>

--- a/TcNo-Acc-Switcher-Globals/Windows.cs
+++ b/TcNo-Acc-Switcher-Globals/Windows.cs
@@ -429,19 +429,7 @@ namespace TcNo_Acc_Switcher_Globals
             }
             catch (Win32Exception win32Exception)
             {
-                if (win32Exception.HResult != -2147467259) throw; // Throw is error is not: Requires elevation
-                try
-                {
-                    startInfo.UseShellExecute = true;
-                    startInfo.Verb = "runas";
-                    _ = Process.Start(startInfo);
-                    return "Started Tray";
-                }
-
-                catch (Win32Exception win32Exception2)
-                {
-                    if (win32Exception2.HResult != -2147467259) throw; // Throw is error is not: cancelled by user
-                }
+                if (win32Exception.HResult != -2147467259) throw;
             }
 
             return "Could not start tray";

--- a/TcNo-Acc-Switcher-Server/Pages/Basic/BasicSwitcherFuncs.cs
+++ b/TcNo-Acc-Switcher-Server/Pages/Basic/BasicSwitcherFuncs.cs
@@ -996,6 +996,7 @@ namespace TcNo_Acc_Switcher_Server.Pages.Basic
             {
                 AccountIds[accId] = newName;
                 SaveAccountIds();
+                Globals.UpdateTrayUserNameByArg(CurrentPlatform.SafeName, $"+{CurrentPlatform.PrimaryId}:" + accId, newName);
             }
             catch (Exception e)
             {

--- a/TcNo-Acc-Switcher-Server/Pages/Steam/SteamSwitcherFuncs.cs
+++ b/TcNo-Acc-Switcher-Server/Pages/Steam/SteamSwitcherFuncs.cs
@@ -152,7 +152,18 @@ namespace TcNo_Acc_Switcher_Server.Pages.Steam
 
             GenericFunctions.FinaliseAccountList();
             AppStats.SetAccountCount("Steam", AppData.SteamUsers.Count);
+            RefreshSteamTrayNames();
             AppData.SteamLoadingProfiles = false;
+        }
+
+        private static void RefreshSteamTrayNames()
+        {
+            foreach (var su in AppData.SteamUsers)
+            {
+                if (string.IsNullOrWhiteSpace(su.SteamId)) continue;
+                var displayName = SteamSettings.TrayAccName ? su.AccName : GetName(su);
+                Globals.UpdateTrayUserNameByArg("Steam", "+s:" + su.SteamId, displayName);
+            }
         }
 
         private static void InsertAccount(Index.Steamuser su)

--- a/TcNo-Acc-Switcher-Tray/Program.cs
+++ b/TcNo-Acc-Switcher-Tray/Program.cs
@@ -67,6 +67,7 @@ namespace TcNo_Acc_Switcher_Tray
         private readonly string _mainProgram = Path.Join(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule?.FileName)!, "TcNo-Acc-Switcher_main.exe");
 
         private NotifyIcon _trayIcon;
+        private ContextMenuStrip _contextMenu;
 
         public AppCont()
         {
@@ -102,10 +103,11 @@ namespace TcNo_Acc_Switcher_Tray
                 tsi.BackColor = Color.FromArgb(255, 34, 34, 34);
                 foreach (var trayUsers in value)
                 {
+                    var displayName = string.IsNullOrWhiteSpace(trayUsers.Name) ? trayUsers.Arg : trayUsers.Name;
                     _ = tsi.DropDownItems.Add(new ToolStripMenuItem
                     {
                         Name = trayUsers.Arg,
-                        Text = GLang.Instance["Tray_Switch", new { account = trayUsers.Name}],
+                        Text = GLang.Instance["Tray_Switch", new { account = displayName}],
                         ForeColor = Color.White,
                         BackColor = Color.FromArgb(255, 34, 34, 34)
                     });
@@ -132,10 +134,18 @@ namespace TcNo_Acc_Switcher_Tray
                     Visible = true
                 };
             else
+            {
+                var previousMenu = _contextMenu;
                 _trayIcon.ContextMenuStrip = contextMenu;
+                previousMenu?.Dispose();
+            }
 
-            _trayIcon.MouseDown += TrayIconOnMouseDown;
-            _trayIcon.DoubleClick += NotifyIcon_DoubleClick;
+            _contextMenu = contextMenu;
+            if (first)
+            {
+                _trayIcon.MouseDown += TrayIconOnMouseDown;
+                _trayIcon.DoubleClick += NotifyIcon_DoubleClick;
+            }
         }
 
         private void TrayIconOnMouseDown(object sender, MouseEventArgs e)
@@ -151,8 +161,10 @@ namespace TcNo_Acc_Switcher_Tray
             {
                 if (item.Name == "EXIT")
                 {
+                    _trayIcon.ContextMenuStrip?.Close();
                     _trayIcon.Visible = false;
                     CloseMainProcess();
+                    _trayIcon.Dispose();
                     Application.Exit();
                 }
                 else StartSwitcher($"{item.Name} quit");
@@ -173,7 +185,20 @@ namespace TcNo_Acc_Switcher_Tray
             var proc = Process.GetProcessesByName("TcNo-Acc-Switcher_main").FirstOrDefault();
             if (proc == null || proc.MainWindowHandle == IntPtr.Zero) return;
             _ = proc.CloseMainWindow();
-            proc.WaitForExit();
+            if (proc.WaitForExit(5000)) return;
+            try
+            {
+                proc.Kill(true);
+                proc.WaitForExit(2000);
+            }
+            catch (Win32Exception)
+            {
+                // The process may have exited between the timeout and the kill attempt.
+            }
+            catch (InvalidOperationException)
+            {
+                // Already exited.
+            }
         }
         private void StartSwitcher(string args = "")
         {
@@ -194,18 +219,8 @@ namespace TcNo_Acc_Switcher_Tray
                     }
                     catch (Win32Exception win32Exception)
                     {
-                        if (win32Exception.HResult != -2147467259) throw; // Throw is error is not: Requires elevation
-                        try
-                        {
-                            startInfo.UseShellExecute = true;
-                            startInfo.Verb = "runas";
-                            _ = Process.Start(startInfo);
-                        }
-
-                        catch (Win32Exception win32Exception2)
-                        {
-                            if (win32Exception2.HResult != -2147467259) throw; // Throw is error is not: cancelled by user
-                        }
+                        if (win32Exception.HResult != -2147467259) throw;
+                        _ = MessageBox.Show(@$"{GLang.Instance["Tray_CantOpenExe"]} {_mainProgram}", GLang.Instance["Tray_LaunchFail"]);
                     }
                 }
                 else


### PR DESCRIPTION
Fixes several tray workflow issues: cached tray names now refresh when Steam/basic account names change, blank tray labels fall back to the switch argument, tray startup is restored when tray mode/startup is enabled, tray Exit no longer waits forever on the main process, and tray launch paths no longer silently retry with UAC elevation. Also updates the CEF fallback code so the client builds with the current CefSharp nullable API. Validated with dotnet build for the tray and client projects; existing dependency vulnerability warnings remain.