### PR TITLE
Fix account username overflow

### DIFF
--- a/frontend/src/styles/acclist.scss
+++ b/frontend/src/styles/acclist.scss
@@ -252,9 +252,13 @@ label.acc {
   }
 
   p {
-    margin: 0;
+    max-width: 9em;
+    margin: 0 auto;
+    overflow: hidden;
     color: var(--text-muted-gray);
     font-size: 0.75em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
Fixes this small bug that is present in both this and the old version.

<img width="229" height="89" alt="{BDCCA3C9-D390-4215-896F-D282663AC1A0}" src="https://github.com/user-attachments/assets/c3ab8aaf-270f-41c5-8d49-3f8f1429f2ba" />
