### PR TITLE
Add Roblox Desktop App support

### DIFF
--- a/Platforms.json
+++ b/Platforms.json
@@ -499,6 +499,21 @@
       "UniqueIdFile": "HKCU\\Software\\Sandbox Interactive GmbH\\Albion Online Client:LastUsedAccountId_h136571812",
       "UniqueIdMethod": "REGKEY"
     },
+    "Roblox": {
+      "Identifiers": ["rb", "roblox", "rblx"],
+      "ExeLocationDefault": "%LocalAppData%\\Roblox\\Versions\\RobloxPlayerBeta.exe",
+      "GetPathFromShortcutNamed": "Roblox Player",
+      "ExesToEnd": ["RobloxPlayerBeta.exe", "RobloxCrashHandler.exe"],
+      "PathListToClear": ["SAME_AS_LOGIN_FILES"],
+      "LoginFiles": {
+        "%LocalAppData%\\Roblox\\LocalStorage\\appStorage.json": "appStorage.json",
+        "%LocalAppData%\\Roblox\\LocalStorage\\RobloxCookies.dat": "RobloxCookies.dat",
+        "%LocalAppData%\\Roblox\\UniversalApp\\WebView2\\EBWebView\\Default\\Network\\Cookies": "WebView2\\Network\\Cookies",
+        "%LocalAppData%\\Roblox\\UniversalApp\\WebView2\\EBWebView\\Default\\Network\\Cookies-journal": "WebView2\\Network\\Cookies-journal"
+      },
+      "ExitBeforeInteract": true,
+      "UniqueIdFile": "JSON_SELECT::%LocalAppData%\\Roblox\\LocalStorage\\appStorage.json::UserId"
+    },
     "Rockstar": {
       "Identifiers": [ "rs", "rockstar", "socialclub" ],
       "ExeLocationDefault": "%ProgramFiles%\\Rockstar Games\\Launcher\\LauncherPatcher.exe",

--- a/frontend/public/img/platform/Roblox.svg
+++ b/frontend/public/img/platform/Roblox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"><path id="FG" d="M394.3 499.96L0 393.58 105.73.04 500 106.42 394.3 499.96zM319.75 210.21l-110.04-30.27-29.46 109.85 110.04 30.27 29.46-109.85z"/></svg>

--- a/frontend/src/Resources/en-US.json
+++ b/frontend/src/Resources/en-US.json
@@ -636,7 +636,7 @@
   "Preview_AccountDropOnRows": "Account rows (profile image drop)",
   "Preview_AccountDropRowNormal": "Normal row",
   "Preview_AccountDropRowDragHover": "Drop receiver (row hover)",
-  "Toast_CrashReported": "A crash report was submitted successfully."
+  "Toast_CrashReported": "A crash report was submitted successfully.",
   "Heading_UpdateAvailable": "Update Available",
   "Button_UpdateNow": "Update Now",
   "Button_OpenDownloadPage": "Download from GitHub",


### PR DESCRIPTION
Adds support for the Roblox Desktop App directly from Roblox. Support for the Microsoft Store version may also work, but I haven’t tested that yet. 

I’m not sure if this was intentionally left out originally, but a friend asked about it, so I added it.