### PR TITLE
Fix tag names overflowing context menus

### DIFF
--- a/frontend/src/styles/context_menu.scss
+++ b/frontend/src/styles/context_menu.scss
@@ -72,6 +72,7 @@
             cursor: pointer;
             position: relative;
             z-index: 1;
+            overflow-wrap: break-word;
         }
 
         button:disabled,


### PR DESCRIPTION
Really small change but it fixes another overflowing issue

Before:
<img width="458" height="120" alt="{6C08A3B5-C49E-489F-BE05-E5F8F252158D}" src="https://github.com/user-attachments/assets/fa5e04a3-dd4d-43da-944e-4b1793311551" />
<img width="633" height="107" alt="{4F19372E-76A2-48A6-8BBA-0693AA732D82}" src="https://github.com/user-attachments/assets/eac0ec19-e19e-4540-a2ad-45b59ab0d819" />

After: 
<img width="227" height="197" alt="{F79471B4-2D4D-4012-BC4C-B1E64840528C}" src="https://github.com/user-attachments/assets/140c1d66-6e99-4ba0-b267-6012a7519503" />
<img width="385" height="115" alt="{9F950363-291E-4757-BADC-8715E09625E5}" src="https://github.com/user-attachments/assets/acf30e5b-8473-44bd-84e4-8c759d39002b" />

